### PR TITLE
fix(cli): make the spec-reading tools complete, discoverable, and cheap

### DIFF
--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: spec
+description: Read and check equation specification JSONs — coefficients, sign consistency, families, and diffs between derivations. Use when inspecting a spec, comparing a re-derivation, or checking whether a component's signs are consistent, instead of reading the JSON directly.
+---
+
+# Reading equation specifications
+
+A spec JSON is ~96,000 tokens; these commands answer a question in a few hundred, and
+the answer comes from a vetted accessor rather than inference by eye. Six confidently
+wrong diagnoses came from ad-hoc `json.load` scans (GH #401) — that is what this
+replaces.
+
+## Start here for corpus-level questions
+
+`tests/data/spec_semantics.txt` already records families, index structure and proven
+sign conflicts for every spec in `examples/data/`. **Read it rather than scanning.**
+Regenerate with `python -m scripts.spec_semantics_report`; a test keeps it current.
+
+## Recipes
+
+**"Is this component's sign wrong?"** — do not compare raw coefficients across
+components; that is misreading #1. Use the check that normalizes by the kinetic
+coefficient:
+
+```bash
+tidal validate SPEC          # reports proven sibling sign conflicts; exit 1 if any
+```
+
+**"What is this coefficient?"**
+
+```bash
+tidal inspect SPEC --coefficient 'h_5:identity(h_5)'
+```
+
+Reports the summed coefficient, the kinetic divisor, the proven sign with its deciding
+tactic, and every other place the quantity is recorded — separating parts of it from
+redundant re-encodings from the *related but distinct* Hamiltonian term.
+
+**"Did re-derivation change the physics?"**
+
+```bash
+tidal inspect OLD.json --diff NEW.json      # exit 1 = real change, 0 = none
+```
+
+Distinguishes a real change from an equation merely rescaled on both sides. A naive diff
+reports the latter as three separate "fixes".
+
+**"What does this equation say?"**
+
+```bash
+tidal inspect SPEC --equation h_5           # also accepts 'a_0,a_1' or 'all'
+tidal inspect SPEC --detail summary         # proven signs only, whole spec, ~4k tokens
+```
+
+**"Which components belong together?"**
+
+```bash
+tidal inspect SPEC --families
+```
+
+Grouped by `tensor_head` and classified by `tensor_indices` — never by the numeric
+suffix. Index 0 is the temporal component of a rank-1 field, but rank-3 torsion has
+components like `t_13 = [2, 0, 2]` where that reading is meaningless.
+
+## What to trust
+
+- A sign verdict says **`unknown` rather than guessing**. Only ~8% of coefficients have
+  a provable sign; the rest are free sweep parameters whose sign genuinely is not
+  knowable. Supply `--assume-positive` / `--assume-nonzero` when you have physical
+  grounds — `kappa` cannot vanish, but `xi` and `b5` genuinely reach zero.
+- Every verdict names the **tactic** that decided it, so it can be audited without
+  re-deriving.
+- Prefer the **text output over `--json`**: measured, `--json` costs ~3x more and buys
+  nothing unless a script is parsing it.
+
+## Reading the equation listing
+
+```text
+[-kappa^(-2)] d2_t(h_5) =
+    + [(B0) + (-2*B0^3*rho)] gradient_x(a_1)
+    + [-kappa^(-2)] laplacian_x(h_5)   eff>0
+```
+
+The kinetic coefficient sits on the LHS, so the line *is* the equation. Each
+`(operator, field)` key appears once with its terms summed. `eps:0,1` marks a key
+spanning perturbative orders.
+
+`eff>0` is the proven sign of the coefficient **after** dividing by the LHS kinetic
+coefficient — **not** the sign of the bracket beside it. Above, `laplacian_x(h_5)`
+prints a negative `[-kappa^(-2)]` yet is `eff>0`, because the LHS carries the same
+factor and the two cancel: a standard wave operator. Reading the bracket's sign as the
+physical sign is the mistake; that is why the marker is prefixed.
+
+## Python API
+
+`tidal.symbolic.spec_query` — `effective_coefficient`, `field_families`,
+`coefficient_provenance`, `diff_systems`, `sibling_sign_conflicts`.
+`tidal.symbolic.sign_algebra` — the sound sign/ratio decisions underneath.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ abstract: "A symbolic physics pipeline for deriving PDEs from Lagrangians using 
 authors:
 - family-names: "Royce"
   given-names: "William"
-version: 0.48.6
+version: 0.48.7
 date-released: "2026-08-18"
 license: MIT
 repository-code: "https://github.com/WilliamRoyce/tidal"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,35 @@ Symbolic physics pipeline: Lagrangian (xAct/Mathematica) -> JSON -> native PDE s
 - **Plane-wave IC snap on periodic grids**: `--ic plane-wave --ic-wavevector k0` auto-snaps `k0` to the nearest discrete Fourier mode `2π·n/L` (clamped below Nyquist) to eliminate spectral leakage. A `Note:` is printed when the snap is significant. Off-grid `k` causes cos(k·x) to leak amplitude onto every discrete mode; for theories with tachyonic eigenvalues at some k-modes (e.g. PGT torsion with cross-coupling) this triggers spurious `SimulationDivergedError`. Sharp 0.1%-scale stability boundaries in parameter space are a signature of this — if seen, check whether the IC wavevector is off-grid. Override with `--ic-no-snap`. See `docs/tex/plane_wave_ic.tex`.
 - **FV ↔ TorsionCDT dark-photon equivalence map (current convention, post-2026-04-24)**: The CDT Lagrangian in `dark_photon_plasma/theory.toml` is `L ⊃ -alpha3·I3` (note the leading minus, standard Proca convention after the 2026-04-24 sign-flip), giving spatial EOM `m² = +2·alpha3`. FV writes `L ⊃ -½·mT²·t·t` → `m² = +mT²`. Equivalence map: **`mT2 = 2·alpha3`** (same-sign). `alpha3 > 0` ↔ `mT2 > 0` = stable Proca. Confirmed bit-exact (Δ/P_max ≈ 1e-14) at campaign parameters; see `examples/dark_photon_plasma/theory.toml:18-35` and `fv_cdt_equivalence_verified.md`. **Old convention (pre-2026-04-24)**: Lagrangian was `+alpha3·I3`, giving `m² = -2·alpha3` and equivalence `mT2 = -2·alpha3` (opposite-sign). All old-convention HPC runs (28216072, 28226826, 28366464) are archived in CAMPAIGN.md as "wrong regime for the Proca dark-photon analogy" — do not reuse those results under the new convention without re-interpretation.
 
+## Reading Equation Specifications
+
+**Never read a spec JSON directly, and never write a fresh scan over `examples/data/`.**
+Both are how six confidently-wrong diagnoses were produced (GH #401). A torsion spec is
+~96,000 tokens of JSON; the commands below answer a question in a few hundred, and the
+answer comes from a vetted accessor rather than from inference by eye.
+
+| question | command | ~tokens |
+| --- | --- | --- |
+| what is this coefficient, and where else is it recorded? | `tidal inspect SPEC --coefficient 'h_5:identity(h_5)'` | 200 |
+| which components belong together, which are temporal? | `tidal inspect SPEC --families` | 130 |
+| what does one equation say? | `tidal inspect SPEC --equation h_5` (accepts `a,b` or `all`) | 760 |
+| did re-derivation change the physics? | `tidal inspect OLD --diff NEW` (exit 1 = real change) | varies |
+| just the proven signs, whole spec | `tidal inspect SPEC --detail summary` | 4,000 |
+
+**Corpus-level questions are already answered.** `tests/data/spec_semantics.txt` is a
+committed report of families, index structure and proven sign conflicts for every spec.
+Read it instead of scanning. Regenerate with `python -m scripts.spec_semantics_report`.
+
+**Prefer the text output to `--json`** — measured, `--json` costs ~3x more and buys
+nothing when you are reading rather than parsing. `--json` is for scripts.
+
+Two properties worth relying on: a sign verdict says `unknown` rather than guessing when
+it cannot be proven, and every verdict names the tactic that decided it. Only ~8% of
+coefficients have a provable sign — most are free sweep parameters — so use
+`--assume-positive`/`--assume-nonzero` when you have physical grounds. Python API:
+`tidal.symbolic.spec_query` (accessors) and `tidal.symbolic.sign_algebra` (the sign
+decisions). See `/spec` for worked recipes.
+
 ## Claude Code Skills
 
 Custom commands in `.claude/skills/` (main conversation only, not available to subagents):

--- a/README.md
+++ b/README.md
@@ -91,14 +91,23 @@ Fields (2 components):
   h_0          dynamical    time_order=2
 
 Equations:
-  d2_t(a_0) = [-omegaP2] identity(a_0) [B0] gradient_x(h_0) +1 laplacian_x(a_0)
-  d2_t(h_0) = [B0^2] identity(h_0) [mg2/kappa^2] identity(h_0) [B0] gradient_x(a_0) [-kappa^(-2)] laplacian_x(h_0)
+  d2_t(a_0) =
+    + [B0] gradient_x(h_0)
+    + [-omegaP2] identity(a_0)
+    + [1.0] laplacian_x(a_0)   eff>0
+  [-kappa^(-2)] d2_t(h_0) =
+    + [B0] gradient_x(a_0)
+    + [(B0^2) + (mg2/kappa^2)] identity(h_0)
+    + [-kappa^(-2)] laplacian_x(h_0)   eff>0
 
 Required parameters:
   B0  (in: a_0, h_0)
   kappa  (in: h_0)
   mg2  (in: h_0)
   omegaP2  (in: a_0)
+
+Mass matrix:    diag(-omegaP2, (B0^2) + (mg2/kappa^2))
+Coupling matrix: zeros(2x2)
 ```
 
 **4. Simulate.** The solver is chosen automatically from the structure of the equations — here the modal solver, since the system is periodic with time-independent coefficients:

--- a/docs/NEXT_PHASES.md
+++ b/docs/NEXT_PHASES.md
@@ -3,7 +3,7 @@
 **Created:** February 2026
 **Last Updated:** April 2026
 **Status:** Phases A, B, C, D, E (FFT), F, J complete; Torsion (PGT) complete (v0.18.0); Torsion-Gertsenshtein investigated (v0.22.8); **Perturbative Reduction v6 complete (v0.33.9, Stage 7 closed 2026-04-20, issue #271 resolved — Euler–Heisenberg + matter-only theories now supported)**; Phases G–I planned
-**Version:** 0.48.6 | **Tests:** 2,449 collected | **Examples:** 19 working (1+1D to 3+1D)
+**Version:** 0.48.7 | **Tests:** 2,449 collected | **Examples:** 19 working (1+1D to 3+1D)
 
 ## Completed — April 2026
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -292,7 +292,7 @@ This project follows [Semantic Versioning](https://semver.org/):
 - **MINOR** (0.X.0): New features (3+1D examples, JSON schema extensions)
 - **PATCH** (0.0.X): Bug fixes, documentation improvements
 
-**Current Version:** 0.48.6
+**Current Version:** 0.48.7
 **Previous Milestones:** 0.3.0 delivered Phase 3 + CLI + rename to TIDAL; 0.4.0 delivered solver migration + gauge fixing + background fields + adaptive timestepping + constraint pre-solve; 0.5.0 delivered parameter sweep framework (Phase C) with 12 measurements, sensitivity analysis, and advanced visualization
 **Next Major Release (1.0.0):** Phase D (Gertsenshtein example) + Wolfram CI
 

--- a/docs/tex/cli_reference.tex
+++ b/docs/tex/cli_reference.tex
@@ -98,6 +98,39 @@ tidal inspect examples/data/chern_simons.json
 
 Output includes: spacetime dimension, field names, equation count, operator types, mass/coupling matrices.
 
+\paragraph{The equation listing.}
+The default listing carries the kinetic coefficient on the left-hand side, so the
+printed line \emph{is} the equation, and shows each \texttt{operator(field)} key once
+with its terms summed:
+
+\begin{lstlisting}[style=bash]
+[-kappa^(-2)] d2_t(h_5) =
+    + [(B0) + (-2*B0^3*rho)] gradient_x(a_1)
+    + [-kappa^(-2)] laplacian_x(h_5)   eff>0
+\end{lstlisting}
+
+Before this, the kinetic coefficient was not printed at all and a key could appear
+twice, so a bare $+1$ in one component and a bare $-1$ in another looked contradictory
+when they were not --- the misreading recorded as row 1 of GH \#401. Above, the
+left-hand side and the laplacian carry the same factor, so they cancel: a standard wave
+operator.
+
+Two annotations appear only when they carry information. \texttt{eff>0} /
+\texttt{eff<0} / \texttt{eff>=0} marks a \emph{proven} sign of the coefficient
+\emph{after} division by the left-hand kinetic coefficient --- which is not generally
+the sign of the bracket beside it, since a negative kinetic coefficient flips the two
+apart. Above, \texttt{laplacian\_x(h\_5)} prints a negative \texttt{[-kappa\^{}(-2)]}
+yet is marked \texttt{eff>0}, because the left-hand side carries the same factor and
+they cancel. Coefficients whose sign cannot be proven are left unmarked rather than
+guessed at. \texttt{eps:0,1} marks a key spanning perturbative
+orders, since summing would otherwise hide the split \texttt{filter\_by\_order} depends
+on. Coordinates print as \texttt{x} rather than the stored \texttt{x[]}, so the brackets
+do not nest inside the coefficient delimiter.
+
+\texttt{--detail summary} reduces the listing to one line per key with only the proven
+sign --- roughly a quarter of the default's size on a 32-component spec, for scanning.
+\texttt{--equation} accepts a comma-separated list or \texttt{all}.
+
 \paragraph{Semantic queries.}
 Four flags read \emph{part} of a spec through the vetted accessors in
 \texttt{tidal/symbolic/spec\_query.py} rather than leaving the reader to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidal"
-version = "0.48.6"
+version = "0.48.7"
 description = "TIDAL: Tensor Integration and Derivation for Any Lagrangian"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -355,7 +355,7 @@ class TestInspectSemanticQueries:
         equations = out.split("Equations:")[1].split("Required parameters")[0]
         assert "eps:0,1" in equations
 
-    def test_sign_marker_is_labelled_as_the_effective_sign(
+    def test_sign_marker_is_labeled_as_the_effective_sign(
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
@@ -364,7 +364,7 @@ class TestInspectSemanticQueries:
         `coupled_scalars` `h_0` prints `[-kappa^(-2)] laplacian_x(h_0)` — a
         negative bracket — while the marker reads `eff>0`. Both are right: the
         LHS carries `-kappa^(-2)` as well, so the two cancel to +1. An
-        unlabelled `>0` beside a visibly negative coefficient is exactly the
+        unlabeled `>0` beside a visibly negative coefficient is exactly the
         kind of two-quantities-one-line confusion this tooling exists to
         remove, so the marker is prefixed `eff`.
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -292,6 +292,132 @@ class TestInspectSemanticQueries:
         for field in ("h_5", "h_6", "h_8"):
             assert field not in real_section
 
+    def test_default_shows_kinetic_coefficient_and_merges_keys(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The default listing is complete and deduplicated (GH #401 row 1).
+
+        The misreading this prevents: `a_0` showed a bare `+1 laplacian_x(a_0)`
+        and `a_1` a bare `-1 laplacian_x(a_1)`, which look contradictory. They
+        are not — `a_1` carries a kinetic coefficient that used to be invisible.
+        The same key also appeared twice per equation, so a reader could take
+        one and miss the other.
+        """
+        ret = main(["inspect", str(self.EXAMPLES / "gertsenshtein_eh.json")])
+        assert ret == 0
+        out = capsys.readouterr().out
+        equations = out.split("Equations:")[1].split("Required parameters")[0]
+
+        # the kinetic coefficient is on the LHS, where it belongs
+        assert "[-1 + 2*B0^2*rho - 16*B0^2*sigma] d2_t(a_1)" in equations
+        # and each (operator, field) key appears exactly once per equation
+        a1_block = equations.split("d2_t(a_1)")[1].split("d2_t(a_2)")[0]
+        assert a1_block.count("laplacian_x(a_1)") == 1
+
+    def test_position_dependent_coefficients_render_without_nested_brackets(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Coordinates print as `x`, not `x[]`, so the coefficient boundary is clear.
+
+        `[...]` delimits the coefficient, and a raw `x[]` inside it nests with
+        that delimiter and makes the end of the coefficient ambiguous.
+        """
+        ret = main(
+            [
+                "inspect",
+                str(self.EXAMPLES / "dark_photon_plasma_e_dual_gaussian.json"),
+            ],
+        )
+        assert ret == 0
+        out = capsys.readouterr().out
+        equations = out.split("Equations:")[1].split("Required parameters")[0]
+        assert "x[]" not in equations
+        assert "sigB" in equations  # the position-dependent coefficients are present
+        # the matrix display carries the same coefficients and the same rationale
+        assert "x[]" not in out
+
+    def test_perturbative_orders_are_flagged_not_hidden(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A key spanning perturbative orders is marked, since merging hides it.
+
+        Euler-Heisenberg `a_0` carries an eps^0 base term and an eps^1
+        correction on the same key. Summing them is right for the coefficient,
+        but the split is what `filter_by_order` depends on, so it must remain
+        visible.
+        """
+        ret = main(["inspect", str(self.EXAMPLES / "euler_heisenberg.json")])
+        assert ret == 0
+        out = capsys.readouterr().out
+        equations = out.split("Equations:")[1].split("Required parameters")[0]
+        assert "eps:0,1" in equations
+
+    def test_sign_marker_is_labelled_as_the_effective_sign(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The sign marker describes the post-division value, and says so.
+
+        `coupled_scalars` `h_0` prints `[-kappa^(-2)] laplacian_x(h_0)` — a
+        negative bracket — while the marker reads `eff>0`. Both are right: the
+        LHS carries `-kappa^(-2)` as well, so the two cancel to +1. An
+        unlabelled `>0` beside a visibly negative coefficient is exactly the
+        kind of two-quantities-one-line confusion this tooling exists to
+        remove, so the marker is prefixed `eff`.
+        """
+        ret = main(["inspect", str(self.EXAMPLES / "coupled_scalars.json")])
+        assert ret == 0
+        equations = capsys.readouterr().out.split("Equations:")[1]
+        line = next(
+            ln for ln in equations.splitlines() if "laplacian_x(h_0)" in ln
+        )
+        assert "[-kappa^(-2)]" in line  # the numerator is negative
+        assert "eff>0" in line  # the effective coefficient is positive
+        # and no bare ">0" that could be read as annotating the bracket
+        assert " >0" not in line.replace("eff>0", "")
+
+    def test_detail_summary_is_substantially_cheaper(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`--detail summary` must actually save context, or it is not worth having."""
+        spec = str(self.EXAMPLES / "torsion_gertsenshtein_complete_even.json")
+        main(["inspect", spec, "--detail", "summary"])
+        summary = len(capsys.readouterr().out)
+        main(["inspect", spec])
+        full = len(capsys.readouterr().out)
+        assert summary < full / 2, f"summary {summary} vs full {full}"
+
+    def test_equation_accepts_a_list_and_all(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """One invocation can cover several components, or every component."""
+        spec = str(self.EXAMPLES / "gertsenshtein_eh.json")
+        assert main(["inspect", spec, "--equation", "a_0,a_1"]) == 0
+        pair = capsys.readouterr().out
+        assert "d2_t(a_0)" in pair
+        assert "d2_t(a_1)" in pair
+
+        assert main(["inspect", spec, "--equation", "all"]) == 0
+        every = capsys.readouterr().out
+        assert every.count("kinetic =") == 6  # all components of this spec
+
+    def test_equation_with_unknown_name_in_a_list_errors(self) -> None:
+        """A bad name anywhere in the list fails before printing a partial answer."""
+        ret = main(
+            [
+                "inspect",
+                str(self.EXAMPLES / "gertsenshtein_eh.json"),
+                "--equation",
+                "a_0,nope",
+            ],
+        )
+        assert ret == 2
+
     def test_diff_json_envelope_carries_component_deltas(self) -> None:
         """`--diff --json` reports verdicts plus components unique to either side."""
         import contextlib

--- a/tidal/cli/__init__.py
+++ b/tidal/cli/__init__.py
@@ -196,11 +196,12 @@ def _build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     )
     inspect_query.add_argument(
         "--equation",
-        metavar="FIELD",
+        metavar="FIELDS",
         default=None,
         help=(
-            "Show one component's equation with effective coefficients "
-            "(all matching terms summed, kinetic coefficient divided out)"
+            "Show a component's equation with effective coefficients (all "
+            "matching terms summed, kinetic coefficient divided out). Accepts "
+            "a comma-separated list, or 'all' for every component"
         ),
     )
     inspect_query.add_argument(
@@ -257,6 +258,17 @@ def _build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
             "Comma-separated parameters to assume non-vanishing without claiming "
             "a sign (e.g. kappa, whose vanishing would remove the Einstein-Hilbert "
             "term). Sharpens kappa^2 from '0+' to '+'"
+        ),
+    )
+    inspect_query.add_argument(
+        "--detail",
+        choices=["summary", "full"],
+        default="full",
+        help=(
+            "How much to print for the equation listing. 'summary' gives one "
+            "line per operator-field key with only the proven sign, which is "
+            "far cheaper for scanning a large spec; 'full' (default) gives the "
+            "equations with their coefficients"
         ),
     )
     inspect_query.add_argument(

--- a/tidal/cli/_inspect.py
+++ b/tidal/cli/_inspect.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from argparse import Namespace
 
+    from tidal.symbolic.json_loader import ComponentEquation
+
 # Known math functions/constants to exclude from parameter discovery
 # (Mathematica + Python names)
 _MATH_NAMES = {
@@ -140,6 +142,11 @@ def discover_parameters(spec: object) -> dict[str, list[str]]:
     return param_map
 
 
+def _show(value: object) -> str:
+    """Render a matrix entry, normalizing xCoba coordinate calls to bare names."""
+    return _COORD_CALL.sub(r"\1", str(value))
+
+
 def _format_matrix(
     matrix: tuple[tuple[float, ...], ...],
     symbolic: tuple[tuple[object, ...], ...] | None = None,
@@ -167,7 +174,7 @@ def _format_matrix(
             diag_entries: list[str] = []
             for i in range(n):
                 s = symbolic[i][i]
-                diag_entries.append(str(s) if s is not None else str(matrix[i][i]))
+                diag_entries.append(_show(s) if s is not None else _show(matrix[i][i]))
             return f"diag({', '.join(diag_entries)})"
         diag_vals = [str(matrix[i][i]) for i in range(n)]
         return f"diag({', '.join(diag_vals)})"
@@ -179,7 +186,7 @@ def _format_matrix(
             entries: list[str] = []
             for j in range(n):
                 s = symbolic[i][j]
-                entries.append(str(s) if s is not None else str(matrix[i][j]))
+                entries.append(_show(s) if s is not None else _show(matrix[i][j]))
             rows.append("  [" + ", ".join(entries) + "]")
         else:
             rows.append("  [" + ", ".join(str(matrix[i][j]) for j in range(n)) + "]")
@@ -224,31 +231,133 @@ def _print_spacetime(spec: object) -> None:
     print()
 
 
-def _print_equations(spec: object) -> None:
-    """Print field summary and detailed equation terms."""
+# Coordinate calls are stored as ``x[]`` (xCoba nullary form). Rendered as a
+# bare ``x`` so the brackets do not nest inside the ``[coefficient]`` display
+# convention, which would make the coefficient boundary ambiguous.
+_COORD_CALL = re.compile(r"\b([A-Za-z]\w*)\[\]")
+
+# Proven-sign markers. Spelled as inequalities rather than ``+``/``-`` so they
+# cannot be confused with the ``+`` that separates terms, and prefixed ``eff``
+# because they describe the coefficient *after* division by the LHS kinetic
+# coefficient -- not the numerator printed in the bracket. Those differ in sign
+# whenever the kinetic coefficient is negative: ``h_0`` in coupled_scalars shows
+# ``[-kappa^(-2)]`` yet is ``eff>0``, because the LHS carries ``-kappa^(-2)``
+# too and the two cancel.
+_SIGN_MARKER = {
+    "positive": "eff>0",
+    "negative": "eff<0",
+    "nonnegative": "eff>=0",
+    "nonpositive": "eff<=0",
+    "zero": "eff=0",
+}
+
+
+def _render_equation(
+    equation: ComponentEquation,
+    *,
+    summary: bool = False,
+) -> list[str]:
+    """Render one equation as lines, kinetic coefficient on the left-hand side.
+
+    The printed line *is* the equation: ``[K] d2_t(phi) = [c] op(field) + ...``.
+    Carrying ``K`` on the LHS is what makes the output complete — without it a
+    reader cannot tell that a bare ``-1`` coefficient in one component and a
+    bare ``+1`` in another may describe the same physics, which is the
+    misreading recorded as row 1 of GH #401.
+
+    Each ``(operator, field)`` key appears exactly once with its terms summed,
+    via :func:`tidal.symbolic.spec_query.effective_coefficient`, so no key can
+    be read while a duplicate goes unnoticed. The individual contributions stay
+    visible inside the sum, preserving base-versus-correction provenance.
+
+    Two annotations appear only when they carry information:
+
+    * ``eps:0,1`` when a key spans perturbative orders — merging would
+      otherwise hide the split ``filter_by_order`` depends on.
+    * ``eff>0`` / ``eff<0`` / ``eff>=0`` when the sign is *proven*. This is the
+      sign of the coefficient **after** dividing by the LHS kinetic
+      coefficient, which is the physically meaningful quantity and is not
+      generally the sign of the bracket beside it: a negative kinetic
+      coefficient flips the two apart. Most coefficients are free parameters
+      whose sign is genuinely unknowable, and those stay unmarked rather than
+      guessed at.
+
+    Parameters
+    ----------
+    equation : ComponentEquation
+        The equation to render.
+    summary : bool
+        Emit one compact line per key with the sign only, omitting coefficients.
+
+    Returns
+    -------
+    list[str]
+        Rendered lines, without trailing newlines.
+    """
+    from tidal.symbolic.spec_query import effective_coefficient
+
+    order = equation.time_derivative_order
+    name = equation.field_name
+    kinetic = equation.kinetic_coefficient_symbolic
+    head = f"d{order}_t({name})" if order else f"{name} (constraint)"
+    kinetic_shown = _COORD_CALL.sub(r"\1", kinetic) if kinetic else None
+    lhs = f"[{kinetic_shown}] {head}" if kinetic_shown else head
+
+    keys = sorted({(t.operator, t.field) for t in equation.rhs_terms})
+    if summary:
+        out: list[str] = []
+        for operator, field in keys:
+            eff = effective_coefficient(equation, field, operator)
+            marker = _SIGN_MARKER.get(eff.sign().sign.value, "?")
+            out.append(f"  {name} {operator}({field}) {marker}")
+        return out
+
+    lines = [f"  {lhs} ="]
+    for operator, field in keys:
+        eff = effective_coefficient(equation, field, operator)
+        coeff = _COORD_CALL.sub(r"\1", eff.numerator)
+        tags: list[str] = []
+        orders = {t.order_in_eps for t in eff.terms}
+        if len(orders) > 1:
+            tags.append("eps:" + ",".join(str(o) for o in sorted(orders)))
+        marker = _SIGN_MARKER.get(eff.sign().sign.value)
+        if marker is not None:
+            tags.append(marker)
+        suffix = "   " + "  ".join(tags) if tags else ""
+        lines.append(f"    + [{coeff}] {operator}({field}){suffix}")
+    return lines
+
+
+def _print_equations(spec: object, *, detail: str = "full") -> None:
+    """Print the field summary and the equations.
+
+    Parameters
+    ----------
+    spec : EquationSystem
+        The loaded equation system.
+    detail : str
+        ``"full"`` for the equation form, ``"summary"`` for one line per key
+        carrying only the proven sign.
+    """
     from tidal.symbolic.json_loader import EquationSystem
 
     if not isinstance(spec, EquationSystem):
         return
-    print(
-        f"Fields ({spec.n_components} component{'s' if spec.n_components != 1 else ''}):",
-    )
-    for eq in spec.equations:
-        t_order = eq.time_derivative_order
-        dynamical = "dynamical" if t_order > 0 else "constraint"
-        print(f"  {eq.field_name:<12s} {dynamical:<12s} time_order={t_order}")
-    print()
 
-    print("Equations:")
+    if detail != "summary":
+        print(
+            f"Fields ({spec.n_components} "
+            f"component{'s' if spec.n_components != 1 else ''}):",
+        )
+        for eq in spec.equations:
+            kind = "dynamical" if eq.time_derivative_order > 0 else "constraint"
+            print(f"  {eq.field_name:<12s} {kind:<12s} time_order={eq.time_derivative_order}")
+        print()
+
+    print("Equations:" if detail != "summary" else "Signs (proven only; ? = undecided):")
     for eq in spec.equations:
-        t_order = eq.time_derivative_order
-        lhs_label = f"d{t_order}_t" if t_order > 0 else "constraint"
-        terms_strs: list[str] = []
-        for term in eq.rhs_terms:
-            sym = term.coefficient_symbolic
-            coeff_str = f"[{sym}]" if sym is not None else f"{term.coefficient:+.4g}"
-            terms_strs.append(f"{coeff_str} {term.operator}({term.field})")
-        print(f"  {lhs_label}({eq.field_name}) = {' '.join(terms_strs)}")
+        for line in _render_equation(eq, summary=detail == "summary"):
+            print(line)
     print()
 
 
@@ -332,7 +441,7 @@ def _build_json_output(spec: object, *, show_params: bool) -> dict[str, Any]:
     return result
 
 
-def inspect_command(args: Namespace) -> int:  # noqa: C901
+def inspect_command(args: Namespace) -> int:  # noqa: C901, PLR0911, PLR0912
     """Execute the inspect command.
 
     Parameters
@@ -408,9 +517,18 @@ def inspect_command(args: Namespace) -> int:  # noqa: C901
         print(system_to_latex(spec, output_format=args.latex_format))
         return 0
 
-    _print_header(spec)
-    _print_spacetime(spec)
-    _print_equations(spec)
+    detail = getattr(args, "detail", "full")
+    if detail != "summary":
+        _print_header(spec)
+        _print_spacetime(spec)
+    _print_equations(spec, detail=detail)
+
+    if detail == "summary":
+        # summary exists to be cheap to scan: the parameter list and the
+        # n x n matrices are the two largest remaining blocks and neither
+        # carries a sign verdict, so they are omitted rather than doubling
+        # the cost of the mode.
+        return 0
 
     # Parameters
     param_map = discover_parameters(spec)

--- a/tidal/cli/_inspect_query.py
+++ b/tidal/cli/_inspect_query.py
@@ -116,24 +116,73 @@ def show_equation(  # noqa: PLR0913
     assume_positive: Iterable[str] | None,
     assume_nonzero: Iterable[str] | None,
 ) -> int:
-    """Print one equation with its effective coefficients.
+    """Print one or more equations with their effective coefficients.
+
+    Parameters
+    ----------
+    field : str
+        A component name, a comma-separated list, or ``all``.
 
     Returns
     -------
     int
-        ``EXIT_OK``, or ``EXIT_ERROR`` if the component is unknown.
+        ``EXIT_OK``, or ``EXIT_ERROR`` if any component is unknown.
     """
-    from tidal.symbolic.spec_query import effective_coefficient
-
-    index = spec.equation_map.get(field)
-    if index is None:
+    requested = _resolve_fields(spec, field)
+    if requested is None:
         return _fail(
             "unknown_component",
-            f"unknown component: {field!r}",
+            f"unknown component in {field!r}",
+            f"Use --families to list components, or --equation all. "
             f"Components: {', '.join(spec.component_names)}",
             as_json=as_json,
         )
 
+    records: list[dict[str, Any]] = []
+    text: list[str] = []
+    for name in requested:
+        text.extend(_equation_lines(spec, name, records, as_json=as_json,
+                                    parameters=parameters,
+                                    assume_positive=assume_positive,
+                                    assume_nonzero=assume_nonzero))
+
+    if as_json:
+        print(json.dumps({"items": [_project(r, fields) for r in records]}, indent=2))
+        return EXIT_OK
+    for line in text:
+        print(line)
+    return EXIT_OK
+
+
+def _resolve_fields(spec: EquationSystem, requested: str) -> list[str] | None:
+    """Expand an ``--equation`` value into component names.
+
+    Accepts a single name, a comma-separated list, or ``all``. Returns ``None``
+    if any name is unknown, so the caller reports one clear error rather than
+    printing part of the answer.
+    """
+    if requested.strip() == "all":
+        return list(spec.component_names)
+    names = [n.strip() for n in requested.split(",") if n.strip()]
+    if any(n not in spec.equation_map for n in names):
+        return None
+    return names
+
+
+def _equation_lines(  # noqa: PLR0913
+    spec: EquationSystem,
+    field: str,
+    records: list[dict[str, Any]],
+    *,
+    as_json: bool,  # noqa: ARG001
+    parameters: Mapping[str, float] | None,
+    assume_positive: Iterable[str] | None,
+    assume_nonzero: Iterable[str] | None,
+) -> list[str]:
+    """Render one component, appending its records for the JSON form."""
+    from tidal.symbolic.spec_query import effective_coefficient
+
+    index = spec.equation_map[field]
     equation = spec.equations[index]
     keys = sorted({(t.operator, t.field) for t in equation.rhs_terms})
 
@@ -147,7 +196,6 @@ def show_equation(  # noqa: PLR0913
         "",
         "  effective coefficients (all matching terms summed, kinetic divided out):",
     ]
-    records: list[dict[str, Any]] = []
     for operator, target in keys:
         eff = effective_coefficient(equation, target, operator)
         result = eff.sign(
@@ -175,13 +223,7 @@ def show_equation(  # noqa: PLR0913
             },
         )
 
-    if as_json:
-        print(json.dumps({"items": [_project(r, fields) for r in records]}, indent=2))
-        return EXIT_OK
-
-    for line in text:
-        print(line)
-    return EXIT_OK
+    return text
 
 
 # --- --coefficient ---
@@ -212,7 +254,8 @@ def show_coefficient(  # noqa: PLR0913, C901
         return _fail(
             "invalid_selector",
             str(exc),
-            "Example: --coefficient 'h_5:laplacian_x(h_5)'",
+            "Example: --coefficient 'h_5:laplacian_x(h_5)'. "
+            "Use --equation FIELD to list the operator(field) keys available.",
             as_json=as_json,
         )
 
@@ -222,6 +265,7 @@ def show_coefficient(  # noqa: PLR0913, C901
         return _fail(
             "unknown_component",
             f"unknown component: {equation_field!r}",
+            f"Use --families to see components grouped by tensor family. "
             f"Components: {', '.join(spec.component_names)}",
             as_json=as_json,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -2241,7 +2241,7 @@ wheels = [
 
 [[package]]
 name = "tidal"
-version = "0.48.6"
+version = "0.48.7"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

Fixes to the equation-spec reading tools added in #401 (already on `main` via #415), after reviewing them for effectiveness — for a person reading a spec, and for Claude, which is the heavier user.

The accessors worked. Three things blunted them, and a fourth turned up in review.

## 1. The default output reproduced the bug the tooling exists to prevent

`tidal inspect` printed every RHS term faithfully but **never printed the kinetic coefficient**, and listed a repeated `(operator, field)` key once per term:

```
d2_t(a_0) = +1 laplacian_x(a_0) [-2*B0^2*rho] laplacian_x(a_0) ...
d2_t(a_1) = ... -1 laplacian_x(a_1) [2*B0^2*rho] laplacian_x(a_1)
```

`a_0` reads `+1`, `a_1` reads `-1`, so they look contradictory. They are not — `a_1` carries `kin = -1 + 2*B0^2*rho - 16*B0^2*sigma`, which appeared nowhere in the output. Nothing printed was false; the reader simply could not compute the equation from what was shown. This is row 1 of the #401 misreading table, still reachable from the primary reading command.

Now the kinetic coefficient sits on the left-hand side, where it belongs, so the printed line **is** the equation, and each key appears once with its terms summed:

```
[-kappa^(-2)] d2_t(h_5) =
    + [(B0) + (-2*B0^3*rho)] gradient_x(a_1)
    + [-kappa^(-2)] laplacian_x(h_5)   eff>0
```

Four further choices, each from rendering the format rather than reasoning about it:

- **Fixed indent, not aligned to `=`.** Alignment padding measured **31% of the output** on a 32-component spec — whitespace a reader gains little from.
- **Coordinates print as `x`**, not the stored `x[]`, which nests inside the `[coefficient]` delimiter and blurs where the coefficient ends.
- **`eps:0,1`** marks a key spanning perturbative orders. Summing is right for the coefficient, but the split is what `filter_by_order` depends on, so hiding it would trade one misreading for another.
- **The sign marker is prefixed `eff`.** It describes the coefficient *after* division by the kinetic coefficient, which is not generally the sign of the bracket beside it. `h_0` in `coupled_scalars` prints `[-kappa^(-2)]` yet is `eff>0`, because the LHS carries the same factor and they cancel. An unlabelled `>0` next to a visibly negative coefficient was itself a two-quantities-one-line trap — caught in review, and now pinned by a test.

## 2. Claude could not discover the tools

`CLAUDE.md` — loaded into every session — never mentioned `--equation`, `--coefficient`, `--families`, `--diff`, `tests/data/spec_semantics.txt`, or the accessor modules. A fresh session fell back to ad-hoc `json.load` scans, which is the exact behaviour #401 exists to eliminate. A tool nobody can find is worth roughly nothing regardless of how well it works.

Adds a `CLAUDE.md` section and a `/spec` skill, both leading with measured cost so the cheap path is the obvious one, and stating two facts that are not guessable:

- Corpus-level questions are already answered in `tests/data/spec_semantics.txt`. Every one of the six #401 misreadings began with a fresh scan.
- Prefer the text output to `--json` — measured, `--json` costs ~3× more and buys nothing when reading rather than parsing.

## 3. No cheap whole-spec view

`--equation` took one field, so a 32-component spec needed 32 invocations. It now accepts a comma list or `all`, and `--detail summary` gives proven signs only.

## Measured

On `torsion_gertsenshtein_complete_even` (32 components):

| view | tokens |
| --- | --- |
| raw JSON | ~96,600 |
| default equations section, before | ~16,400 |
| default equations section, after | ~11,500 (30% cheaper, and complete) |
| `--detail summary` | ~4,100 |
| `--coefficient 'h_5:identity(h_5)'` | ~200 |

Worth stating plainly: only **~8%** of coefficients have a provable sign. That is not a weakness — most are free sweep parameters whose sign genuinely is not knowable, and the layer refuses to guess. It does mean an unmarked coefficient reads as "not proven", not "unconstrained", and `--assume-positive` / `--assume-nonzero` are how to raise decidability when there are physical grounds.

## Verification

- `2582 passed, 5 skipped`; `ruff` and `pyright` clean on changed files.
- The README example showed the old format — including the duplicate `identity(h_0)` — and is regenerated from real command output.
- `tests/data/spec_semantics.txt` regenerates with no diff, confirming no semantic change.
- New tests cover the two ways the format could be *wrong* rather than merely ugly: a position-dependent spec must render `x` not `x[]`, and a perturbative spec must still show `eps:0,1`.
