### PR TITLE
fix: ruff format + CI gate, shuttle pull paths, tidal list on wheels, kappa dims (#399, #328, #418, #338)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# Revisions listed here are excluded from `git blame` output.
+#
+# Enable locally with:
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Only whole-tree, semantically inert reformats belong in this file.
+
+# style: apply ruff format across the codebase (#399)
+# 52 files, formatting only -- ASTs verified identical before and after.
+1246d7a546e9217dfcce0e000b57aeddea965ed2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run lint
         run: uv run ruff check --output-format=github
 
+      - name: Check formatting
+        run: uv run ruff format --check .
+
       - name: Run type check
         run: uv run pyright
 

--- a/examples/torsion_gertsenshtein/plot_frequency_modification.py
+++ b/examples/torsion_gertsenshtein/plot_frequency_modification.py
@@ -79,7 +79,12 @@ def main() -> None:
         try:
             times, p_vals = compute_p(dirname)
             ax_pt.plot(
-                times, p_vals, color=color, linewidth=1.5, label=label, alpha=0.85,
+                times,
+                p_vals,
+                color=color,
+                linewidth=1.5,
+                label=label,
+                alpha=0.85,
             )
         except FileNotFoundError:
             print(f"  Warning: {dirname} not found, skipping")

--- a/examples/torsion_gertsenshtein/schur_complement_analysis.py
+++ b/examples/torsion_gertsenshtein/schur_complement_analysis.py
@@ -76,7 +76,12 @@ def extract_h5_a1_block(
     """
     coeff_eval = CoefficientEvaluator(spec, grid, params)
     A_reduced, _, _, _, _, mapping = _build_evolution_matrices(
-        spec, layout, grid, coeff_eval, k_grid, rfft_shape,
+        spec,
+        layout,
+        grid,
+        coeff_eval,
+        k_grid,
+        rfft_shape,
     )
 
     # Map original slots to reduced slots
@@ -362,7 +367,12 @@ def mini_solver_amplification(
         """Get the full 14x14 reduced system and slot mapping."""
         coeff_eval = CoefficientEvaluator(spec, grid, params)
         A_red, _, _, _, _, mapping = _build_evolution_matrices(
-            spec, layout, grid, coeff_eval, k_grid, rfft_shape,
+            spec,
+            layout,
+            grid,
+            coeff_eval,
+            k_grid,
+            rfft_shape,
         )
         return A_red, mapping
 

--- a/manuscript/macros.tex
+++ b/manuscript/macros.tex
@@ -118,7 +118,7 @@
 \newcommand*{\SUNDIALS}{\textit{SUNDIALS}\xspace}
 
 % === Planck scale ===
-% Reduced Planck mass: M_P, with M_P^2 = 1/(8 pi G), units [Mass]
+% Reduced Planck mass: M_P, with M_P^2 = 1/(8 pi G), units [Mass^2]
 % Convention: MacrosMAG.tex (2406.12826); BHL joint corpus
 %
 % Relation to TIDAL's kappa (see "Gravitational coupling" block below):
@@ -141,7 +141,7 @@
 %   - Metric perturbation:  g_{mu nu} = eta_{mu nu} + h_{mu nu}
 %     (RAW perturbation, NO kappa factor in the field redefinition)
 %   - Action prefactor:     L = (1/kappa^2) R - (1/4) F^2
-%   - Numerical value:      kappa^2 = 16 pi G,   units [Mass^{-1}]
+%   - Numerical value:      kappa^2 = 16 pi G,   units [Mass^{-2}]
 %   - Planck-mass relation: kappa = sqrt(2)/M_P,  M_P = sqrt(2)/kappa
 %
 % kappa appears in two places:
@@ -292,7 +292,7 @@
 %   Convention: Hehl et al. Rev.Mod.Phys. 48, 393 (1976); Shapiro hep-th/0103093
 %   Macro: \MAGT{^\alpha_\mu_\nu} or \T[]{mu nu rho} for irrep components
 %
-% Gravitational coupling (vertex):  kappa^2 = 16 pi G,  units [Mass^{-1}]
+% Gravitational coupling (vertex):  kappa^2 = 16 pi G,  units [Mass^{-2}]
 %   - Appears in g = eta + kappa h and in P_conv = sin^2(kappa B_0 D / 2)
 %   - NOT the same as the Einstein-action constant kappa_E = 8 pi G
 %   - See the full block-comment in the "Gravitational coupling" section above
@@ -305,7 +305,7 @@
 %   Macro: \Alp{n}, \Bet{n}, \Gam{n}
 %
 % Planck mass:  m_P  (reduced Planck mass)
-%   m_P^2 = 1 / (8 pi G) = 2 / kappa^2,    units [Mass]
+%   m_P^2 = 1 / (8 pi G) = 2 / kappa^2,    units [Mass^2]
 %   m_P = sqrt(2) / kappa
 %   - Action prefactor on Ricci scalar: -(1/2) m_P^2 R  (BHL joint convention)
 %   Convention: MacrosMAG.tex (2406.12826); BHL joint papers

--- a/research/perturbative_hamiltonian/reviews/scripts_review/C8_F_vs_J_structural_diff.py
+++ b/research/perturbative_hamiltonian/reviews/scripts_review/C8_F_vs_J_structural_diff.py
@@ -31,7 +31,6 @@ DIFF:
     mass, decoupling.  Auxiliaries h, b, a have finite kinetic.
 """
 
-
 import sympy as sp
 from sympy import Matrix, symbols
 

--- a/research/perturbative_hamiltonian/scripts/curtright_stueckelberg_q.py
+++ b/research/perturbative_hamiltonian/scripts/curtright_stueckelberg_q.py
@@ -432,7 +432,9 @@ def EL(L, q):
     return sp.diff(L, q) - sp.diff(sp.diff(L, sp.diff(q, t)), t)
 
 
-EOMs = {n: sp.simplify(EL(L_min_IBP, q)) for n, q in zip(field_names, fields, strict=False)}
+EOMs = {
+    n: sp.simplify(EL(L_min_IBP, q)) for n, q in zip(field_names, fields, strict=False)
+}
 for n, eqn in EOMs.items():
     log(f"EOM[{n}] =", eqn)
 

--- a/research/perturbative_hamiltonian/scripts/line6_dual_formulation.py
+++ b/research/perturbative_hamiltonian/scripts/line6_dual_formulation.py
@@ -53,7 +53,6 @@ CRITICAL TEST: does the Curtright/dual-graviton formulation of the tensor
 torsion sector convert b5·(∂q)^2 into a regular kinetic term + auxiliary?
 """
 
-
 print("=" * 72)
 print("LINE 6: Dual formulation / Curtright-Hull duality")
 print("=" * 72)

--- a/research/perturbative_hamiltonian/scripts/recipe1_debug_R_squared.py
+++ b/research/perturbative_hamiltonian/scripts/recipe1_debug_R_squared.py
@@ -66,11 +66,16 @@ def build_q_basis_constrained():
     constraints = []
     for a, b, cc in product(range(4), repeat=3):
         constraints.append(c[a, b, cc] + c[a, cc, b])
-    constraints.extend(sum(ETA_INV[a, a] * c[a, a, cc] for a in range(4)) for cc in range(4))
-    constraints.extend(sum(
-                eps_down(a, b, cc, d) * c[a, b, cc]
-                for a, b, cc in product(range(4), repeat=3)
-            ) for d in range(4))
+    constraints.extend(
+        sum(ETA_INV[a, a] * c[a, a, cc] for a in range(4)) for cc in range(4)
+    )
+    constraints.extend(
+        sum(
+            eps_down(a, b, cc, d) * c[a, b, cc]
+            for a, b, cc in product(range(4), repeat=3)
+        )
+        for d in range(4)
+    )
     sol = sp.linsolve(constraints, syms)
     sub = dict(zip(syms, next(iter(sol)), strict=False))
     free = set()

--- a/research/perturbative_hamiltonian/scripts/recipe1_preflight_q_projection.py
+++ b/research/perturbative_hamiltonian/scripts/recipe1_preflight_q_projection.py
@@ -384,7 +384,9 @@ DT_x_DT_TERMS = [
 
 
 def main():
-    out_dir = pathlib.Path(pathlib.Path(__file__).resolve()).parent.replace("scripts", "results")
+    out_dir = pathlib.Path(pathlib.Path(__file__).resolve()).parent.replace(
+        "scripts", "results"
+    )
     pathlib.Path(out_dir).mkdir(exist_ok=True, parents=True)
     transcript_path = os.path.join(out_dir, "recipe1_preflight_transcript.txt")
     json_path = os.path.join(out_dir, "recipe1_q_kinetic_structure.json")

--- a/research/perturbative_hamiltonian/scripts/vt_T4_3plus3_PGT.py
+++ b/research/perturbative_hamiltonian/scripts/vt_T4_3plus3_PGT.py
@@ -876,7 +876,9 @@ constraint_data = {
     },
 }
 
-with Path(results_dir / "vt_T4_constraint_matrix.json").open("w", encoding="utf-8") as f:
+with Path(results_dir / "vt_T4_constraint_matrix.json").open(
+    "w", encoding="utf-8"
+) as f:
     json.dump(constraint_data, f, indent=2)
 print(f"Wrote constraint analysis to: {results_dir / 'vt_T4_constraint_matrix.json'}")
 print()

--- a/scripts/benchmarks/boccaletti_uniform_rich.py
+++ b/scripts/benchmarks/boccaletti_uniform_rich.py
@@ -472,9 +472,7 @@ def append_convergence(*, out: Path, parallel: int, work_dir: Path) -> None:
             f"--append-convergence requires existing {out}; run the full "
             "benchmark first."
         )
-        raise FileNotFoundError(
-            msg
-        )
+        raise FileNotFoundError(msg)
     with out.open(encoding="utf-8") as fh:
         data = json.load(fh)
     existing = data.get("convergence", [])
@@ -484,9 +482,7 @@ def append_convergence(*, out: Path, parallel: int, work_dir: Path) -> None:
     t_converge = data["metadata"]["parameters"].get("t_converge_point")
     if b0_converge is None or t_converge is None:
         msg = "existing JSON metadata lacks b0_converge_point/t_converge_point"
-        raise RuntimeError(
-            msg
-        )
+        raise RuntimeError(msg)
 
     work_dir.mkdir(parents=True, exist_ok=True)
     new_rows: list[dict] = []

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -535,7 +535,11 @@ class VersionBumper:
                 self.citation_cff,
                 self.root / "uv.lock",
             ]
-            files_to_stage.extend(optional for optional in [self.next_phases_md, self.roadmap_md, self.security_md] if optional.exists())
+            files_to_stage.extend(
+                optional
+                for optional in [self.next_phases_md, self.roadmap_md, self.security_md]
+                if optional.exists()
+            )
             subprocess.run(
                 ["git", "add", "--", *[str(f) for f in files_to_stage]],
                 cwd=self.root,

--- a/scripts/figures/fig2_propagating_torsion_map.py
+++ b/scripts/figures/fig2_propagating_torsion_map.py
@@ -18,9 +18,7 @@ from __future__ import annotations
 
 def main() -> None:
     msg = "fig2_propagating_torsion_map: implement during the §4.4 drafting session."
-    raise NotImplementedError(
-        msg
-    )
+    raise NotImplementedError(msg)
 
 
 if __name__ == "__main__":

--- a/scripts/figures/fig3_trace_ghost_growth.py
+++ b/scripts/figures/fig3_trace_ghost_growth.py
@@ -24,9 +24,7 @@ def main() -> None:
         "fig3_trace_ghost_growth: implement during the §4.5 drafting session "
         "(conditional on data quality)."
     )
-    raise NotImplementedError(
-        msg
-    )
+    raise NotImplementedError(msg)
 
 
 if __name__ == "__main__":

--- a/scripts/figures/figC1_solver_convergence.py
+++ b/scripts/figures/figC1_solver_convergence.py
@@ -19,9 +19,7 @@ from __future__ import annotations
 
 def main() -> None:
     msg = "figC1_solver_convergence: implement during the App C drafting session."
-    raise NotImplementedError(
-        msg
-    )
+    raise NotImplementedError(msg)
 
 
 if __name__ == "__main__":

--- a/scripts/hpc_shuttle.sh
+++ b/scripts/hpc_shuttle.sh
@@ -231,6 +231,11 @@ cmd_submit() {
   if [[ -n "$campaign" ]]; then
     recorded_cmd="${cmd//\$\{CAMPAIGN_DIR\}/${camp_path}}"
   fi
+  # ${RESULTS_DIR} is only defined inside the sbatch script on the compute
+  # node, so a literal one recorded here would be unresolvable at pull time.
+  # The job id is known now, so expand it to the same path the template uses.
+  recorded_cmd="${recorded_cmd//\$\{RESULTS_DIR\}/${REMOTE_ROOT}/hpc_results/${jobid}}"
+  recorded_cmd="${recorded_cmd//\$RESULTS_DIR/${REMOTE_ROOT}/hpc_results/${jobid}}"
   echo "$(date -Iseconds) $jobid $name $template $recorded_cmd" >> "$JOBS_FILE"
   echo "$jobid"
   # User-visible reminder: HPC jobs that crash on startup typically die
@@ -307,6 +312,10 @@ cmd_pull() {
       line="$(awk -v j="$jobid" '$2==j' "$JOBS_FILE" | tail -1)"
       if [[ -n "$line" ]]; then
         src="$(sed -n 's/.*--output \([^ ]*\).*/\1/p' <<<"$line")"
+        # Records written before ${RESULTS_DIR} was expanded at submit time
+        # carry the literal string.  Resolve it here so historical jobs pull.
+        src="${src//\$\{RESULTS_DIR\}/${REMOTE_ROOT}/hpc_results/${jobid}}"
+        src="${src//\$RESULTS_DIR/${REMOTE_ROOT}/hpc_results/${jobid}}"
       fi
     fi
     [[ -n "$src" ]] || die "could not resolve remote output path for job $jobid; pass --src PATH explicitly"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -380,7 +380,9 @@ _CONSTRAINT_SPEC: dict[str, object] = {
 
 
 def _write_inline_json(
-    tmp_path_factory: pytest.TempPathFactory, spec: dict[str, object], name: str,
+    tmp_path_factory: pytest.TempPathFactory,
+    spec: dict[str, object],
+    name: str,
 ) -> Path:
     """Write an inline JSON spec dict to a temp file and return its path."""
     d = tmp_path_factory.getbasetemp() / "inline_specs"
@@ -401,7 +403,9 @@ def inline_kg_1d_json(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def inline_coupled_scalars_json(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Inline coupled-scalars JSON spec (always available)."""
     return _write_inline_json(
-        tmp_path_factory, _COUPLED_SCALARS_SPEC, "coupled_scalars.json",
+        tmp_path_factory,
+        _COUPLED_SCALARS_SPEC,
+        "coupled_scalars.json",
     )
 
 
@@ -415,7 +419,9 @@ def inline_em_1d_json(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def inline_constraint_json(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Inline constraint (Poisson) JSON spec (always available)."""
     return _write_inline_json(
-        tmp_path_factory, _CONSTRAINT_SPEC, "electrostatics_2d.json",
+        tmp_path_factory,
+        _CONSTRAINT_SPEC,
+        "electrostatics_2d.json",
     )
 
 

--- a/tests/test_analytical_jacobian.py
+++ b/tests/test_analytical_jacobian.py
@@ -643,7 +643,12 @@ class TestJacobianDelivery:
         # Lower DENSE_THRESHOLD so system is in sparse tier
         with patch("tidal.solver._types.DENSE_THRESHOLD", 1):
             result = try_analytical_jacobian(
-                options, spec, layout, grid, "periodic", {},
+                options,
+                spec,
+                layout,
+                grid,
+                "periodic",
+                {},
             )
 
         assert result is True
@@ -709,7 +714,12 @@ class TestJacobianDelivery:
             patch("tidal.solver._types.SUPERLU_NNZ_LIMIT", 1),
         ):
             result = try_analytical_jacobian(
-                options, spec, layout, grid, "periodic", {},
+                options,
+                spec,
+                layout,
+                grid,
+                "periodic",
+                {},
             )
 
         assert result is True
@@ -846,7 +856,10 @@ class TestCirculantOperatorMatrix:
             mat = build_operator_matrix(op, grid, ("periodic", "periodic", "periodic"))
             ref = self._build_probing(op, grid, ("periodic", "periodic", "periodic"))
             np.testing.assert_allclose(
-                mat.toarray(), ref.toarray(), atol=1e-14, err_msg=f"{op} mismatch",
+                mat.toarray(),
+                ref.toarray(),
+                atol=1e-14,
+                err_msg=f"{op} mismatch",
             )
 
     def test_identity_uses_probing_fallback(self) -> None:
@@ -912,7 +925,9 @@ class TestMultiTheorySparseJacobian:
             grid = GridInfo(bounds=((0, 10),), shape=(16,), periodic=(True,))
         elif ndim == 2:
             grid = GridInfo(
-                bounds=((0, 10), (0, 10)), shape=(6, 6), periodic=(True, True),
+                bounds=((0, 10), (0, 10)),
+                shape=(6, 6),
+                periodic=(True, True),
             )
         else:
             grid = GridInfo(
@@ -1034,7 +1049,12 @@ class TestTryAnalyticalJacobian:
 
         options: dict[str, Any] = {}
         result = try_analytical_jacobian(
-            options, spec, layout, grid, "periodic", {"H": 1.0},
+            options,
+            spec,
+            layout,
+            grid,
+            "periodic",
+            {"H": 1.0},
         )
 
         assert result is False
@@ -1654,7 +1674,12 @@ class TestSuperLUNnzFallback:
         ):
             warnings.simplefilter("always")
             configure_linear_solver(
-                options, layout, spec, grid, "periodic", parameters={"H": 1.0},
+                options,
+                layout,
+                spec,
+                grid,
+                "periodic",
+                parameters={"H": 1.0},
             )
 
         assert options["linsolver"] == "gmres"
@@ -1681,7 +1706,12 @@ class TestSuperLUNnzFallback:
         options: dict[str, Any] = {}
         with patch("tidal.solver._types.DENSE_THRESHOLD", 1):
             configure_linear_solver(
-                options, layout, spec, grid, "periodic", parameters={"H": 1.0},
+                options,
+                layout,
+                spec,
+                grid,
+                "periodic",
+                parameters={"H": 1.0},
             )
 
         assert options["linsolver"] == "sparse"
@@ -1707,7 +1737,12 @@ class TestSuperLUNnzFallback:
         ):
             warnings.simplefilter("always")
             configure_linear_solver(
-                options, layout, spec, grid, "periodic", parameters={"H": 1.0},
+                options,
+                layout,
+                spec,
+                grid,
+                "periodic",
+                parameters={"H": 1.0},
             )
 
         user_warnings = [

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -150,7 +150,9 @@ date-released: 2026-01-01
         return temp_dir
 
     def test_get_current_versions(
-        self, mock_project: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        mock_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test reading current versions from files."""
         bumper = VersionBumper("0.2.0", dry_run=True)
@@ -166,7 +168,9 @@ date-released: 2026-01-01
         assert "__init__.py" not in versions
 
     def test_update_pyproject_toml_regex(
-        self, mock_project: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        mock_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test updating pyproject.toml with regex (no tomli_w)."""
         bumper = VersionBumper("0.2.0", dry_run=False)
@@ -186,7 +190,9 @@ date-released: 2026-01-01
             scripts.bump_version.has_tomli_w = original_has_tomli
 
     def test_update_citation_cff_regex(
-        self, mock_project: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        mock_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test updating CITATION.cff with regex (no ruamel.yaml)."""
         bumper = VersionBumper("0.2.0", dry_run=False)
@@ -211,7 +217,9 @@ date-released: 2026-01-01
             scripts.bump_version.has_ruamel_yaml = original_has_ruamel
 
     def test_update_next_phases_md(
-        self, mock_project: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        mock_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test updating version in docs/NEXT_PHASES.md."""
         bumper = VersionBumper("0.2.0", dry_run=False)
@@ -225,7 +233,9 @@ date-released: 2026-01-01
         assert "**Tests:** 100 collected" in content
 
     def test_update_roadmap_md(
-        self, mock_project: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        mock_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test updating current version in docs/ROADMAP.md."""
         bumper = VersionBumper("0.2.0", dry_run=False)
@@ -239,7 +249,9 @@ date-released: 2026-01-01
         assert "0.0.1 delivered initial" in content
 
     def test_update_security_md(
-        self, mock_project: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        mock_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test updating supported version table in SECURITY.md."""
         bumper = VersionBumper("0.6.0", dry_run=False)
@@ -264,7 +276,9 @@ class TestBackupRestore:
             yield Path(tmpdir)
 
     def test_backup_creation(
-        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        temp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that backups are created correctly."""
         # Create test files
@@ -287,7 +301,9 @@ class TestBackupRestore:
         assert backup_file.read_text() == "original content"
 
     def test_backup_restore(
-        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        temp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that backups are restored on rollback."""
         # Create test files
@@ -328,7 +344,9 @@ class TestErrorConditions:
             bumper.validate()
 
     def test_missing_file_raises_error(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that missing file raises error during validation."""
         bumper = VersionBumper("0.2.0", dry_run=False, allow_dirty=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -692,11 +693,48 @@ class TestListCommand:
 
         out = capsys.readouterr().out
         assert "klein_gordon_1d.json" in out
-        assert "specifications found" in out
+        # The inline-spec fixtures share one session directory, so the count
+        # depends on which other fixtures have run.  Match either form rather
+        # than depending on test ordering.
+        assert re.search(r"\d+ specifications? found", out)
 
-    def test_list_nonexistent_dir(self) -> None:
+    def test_list_nonexistent_dir(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         ret = main(["list", "--dir", "/nonexistent/dir"])
         assert ret == 1
+
+        err = capsys.readouterr().err
+        assert "/nonexistent/dir" in err
+        assert "--dir" in err
+
+    def test_list_no_examples_dir_hints_at_repository(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Installed-from-a-wheel case: no examples/data anywhere (#418).
+
+        The distribution ships only the ``tidal`` package, so neither the
+        cwd nor the package parent holds ``examples/data``.  The user gets
+        an actionable hint rather than an empty table.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            "tidal.cli._list._find_examples_dir",
+            lambda: tmp_path / "examples" / "data",
+        )
+
+        ret = main(["list"])
+        assert ret == 1
+
+        err = capsys.readouterr().err
+        assert "no examples directory found" in err
+        # Points at the repository rather than just reporting a missing path.
+        assert "repository" in err
+        assert "--dir" in err
 
 
 class TestSimulateCommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -371,9 +371,7 @@ class TestInspectSemanticQueries:
         ret = main(["inspect", str(self.EXAMPLES / "coupled_scalars.json")])
         assert ret == 0
         equations = capsys.readouterr().out.split("Equations:")[1]
-        line = next(
-            ln for ln in equations.splitlines() if "laplacian_x(h_0)" in ln
-        )
+        line = next(ln for ln in equations.splitlines() if "laplacian_x(h_0)" in ln)
         assert "[-kappa^(-2)]" in line  # the numerator is negative
         assert "eff>0" in line  # the effective coefficient is positive
         # and no bare ">0" that could be read as annotating the bracket

--- a/tests/test_critical_field.py
+++ b/tests/test_critical_field.py
@@ -188,7 +188,10 @@ class TestInterpolation:
 
         # Without interpolation
         result_no_interp = compute_critical_field(
-            sweep, "B0", threshold=0.5, interpolate=False,
+            sweep,
+            "B0",
+            threshold=0.5,
+            interpolate=False,
         )
         b_min_no_interp = result_no_interp.rows[0]["B_min"]
 

--- a/tests/test_examples_curvilinear.py
+++ b/tests/test_examples_curvilinear.py
@@ -121,7 +121,9 @@ class TestVolumeElementGuard:
             ]
         import tempfile
 
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json", delete=False) as fh:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", suffix=".json", delete=False
+        ) as fh:
             json.dump(stripped, fh)
             broken = Path(fh.name)
         try:
@@ -187,7 +189,9 @@ class TestTemporalSignGuard:
                     term["coefficient_symbolic"] = f"-({term['coefficient_symbolic']})"
         import tempfile
 
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json", delete=False) as fh:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", suffix=".json", delete=False
+        ) as fh:
             json.dump(data, fh)
             broken = Path(fh.name)
         try:

--- a/tests/test_new_measurements.py
+++ b/tests/test_new_measurements.py
@@ -231,7 +231,8 @@ class TestAsymptoticConversion:
         data = _make_traveling_wave_data()
         result = compute_asymptotic_conversion(data, "phi_0", "chi_0")
         assert result.P_transmitted + result.P_reflected == pytest.approx(
-            result.P_final, rel=1e-2,
+            result.P_final,
+            rel=1e-2,
         )
 
     def test_source_wavevector_positive(self) -> None:

--- a/tests/test_perturbative_algebraic_constraint.py
+++ b/tests/test_perturbative_algebraic_constraint.py
@@ -284,7 +284,9 @@ class TestPass1ConstraintAndDynamicalAgree:
             expected_lhs_feedback = -b5 * omega2 * _G * phi0
             actual_lhs_feedback = h1 - _G * phi1
             np.testing.assert_allclose(
-                actual_lhs_feedback, expected_lhs_feedback, atol=1e-10,
+                actual_lhs_feedback,
+                expected_lhs_feedback,
+                atol=1e-10,
             )
 
     def test_combined_total_includes_both_passes(self) -> None:
@@ -387,7 +389,12 @@ class TestAugmentedRecoveryMatchesMpmath:
         _spec, solver, grid, y0, layout = _setup()
         params = {"m2": _M2, "b5": 1e-3, "g": _G}
         res = solver.solve(
-            y0, grid, (0.0, 0.5), order=1, parameters=params, num_snapshots=11,
+            y0,
+            grid,
+            (0.0, 0.5),
+            order=1,
+            parameters=params,
+            num_snapshots=11,
         )
         n = grid.num_points
         phi_slot = layout.field_slot_map["phi"]

--- a/tests/test_plot_panels.py
+++ b/tests/test_plot_panels.py
@@ -234,7 +234,11 @@ class TestRenderSweep1dGrouped:
         results = _make_sweep_results(n_points=5, n_params=2)
         fig, ax = plt.subplots()
         render_sweep_1d_grouped(
-            ax, results, "P_max", x_param="param1", group_param="param0",
+            ax,
+            results,
+            "P_max",
+            x_param="param1",
+            group_param="param0",
         )
         # One line per unique value of param0 (the group parameter).
         # The _make_sweep_results fixture uses linspace(-1, 1, 5) so
@@ -261,7 +265,11 @@ class TestRenderSweep1dGrouped:
         fig, ax = plt.subplots()
         with pytest.raises(ValueError, match="exactly 2 swept parameters"):
             render_sweep_1d_grouped(
-                ax, results_1d, "P_max", x_param="param0", group_param="param0",
+                ax,
+                results_1d,
+                "P_max",
+                x_param="param0",
+                group_param="param0",
             )
         plt.close(fig)
 
@@ -270,7 +278,11 @@ class TestRenderSweep1dGrouped:
         fig, ax = plt.subplots()
         with pytest.raises(ValueError, match="exactly 2 swept parameters"):
             render_sweep_1d_grouped(
-                ax, results_3d, "P_max", x_param="param0", group_param="param1",
+                ax,
+                results_3d,
+                "P_max",
+                x_param="param0",
+                group_param="param1",
             )
         plt.close(fig)
 

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -255,7 +255,8 @@ class TestLoadResumeState:
         from tidal.symbolic import load_equation_system
 
         snap_dir = _make_snapshot_dir(
-            tmp_path, parameters={"m2": math.pi, "coupling": 0.5},
+            tmp_path,
+            parameters={"m2": math.pi, "coupling": 0.5},
         )
         spec = load_equation_system(kg_spec)
 
@@ -290,7 +291,9 @@ class TestLoadResumeState:
         np.testing.assert_array_equal(actual, expected.ravel())
 
     def test_negative_snapshot_index_raises(
-        self, tmp_path: Path, kg_spec: Path,
+        self,
+        tmp_path: Path,
+        kg_spec: Path,
     ) -> None:
         """Negative snapshot indices raise ValueError."""
         from tidal.symbolic import load_equation_system
@@ -459,7 +462,9 @@ class TestSimulateResume:
         np.testing.assert_allclose(ckpt_vel, resumed_vel, atol=1e-10)
 
     def test_resume_specific_snapshot(
-        self, inline_kg_1d_json: Path, tmp_path: Path,
+        self,
+        inline_kg_1d_json: Path,
+        tmp_path: Path,
     ) -> None:
         """Resume from a specific mid-run snapshot."""
         from tidal.cli import main
@@ -564,7 +569,9 @@ class TestSimulateResume:
         assert ret == 1
 
     def test_resume_parameter_override(
-        self, inline_kg_1d_json: Path, tmp_path: Path,
+        self,
+        inline_kg_1d_json: Path,
+        tmp_path: Path,
     ) -> None:
         """CLI --param overrides checkpoint metadata parameters."""
         from tidal.cli import main

--- a/tests/test_solver_constraint_solve.py
+++ b/tests/test_solver_constraint_solve.py
@@ -331,7 +331,12 @@ class TestClassifyTerms:
 
         eq = spec.equations[0]
         terms = _classify_terms(
-            0, eq.rhs_terms, "A_0", coeff_eval, 0.0, eq.constraint_solver,
+            0,
+            eq.rhs_terms,
+            "A_0",
+            coeff_eval,
+            0.0,
+            eq.constraint_solver,
         )
 
         # Self-terms: laplacian_x(A_0) + laplacian_y(A_0)
@@ -356,7 +361,12 @@ class TestClassifyTerms:
 
         eq = spec.equations[0]
         terms = _classify_terms(
-            0, eq.rhs_terms, "A_0", coeff_eval, 0.0, eq.constraint_solver,
+            0,
+            eq.rhs_terms,
+            "A_0",
+            coeff_eval,
+            0.0,
+            eq.constraint_solver,
         )
         assert not terms.has_position_dependent_self
 
@@ -368,7 +378,10 @@ class TestClassifyTerms:
 
 class TestSelectMethod:
     def _make_terms(
-        self, *, periodic: bool = True, pos_dep: bool = False,
+        self,
+        *,
+        periodic: bool = True,
+        pos_dep: bool = False,
     ) -> tuple[_ConstraintTerms, GridInfo]:
         grid = GridInfo(
             bounds=((0, 10), (0, 10)),
@@ -469,7 +482,9 @@ class TestFFTSolver:
         nx, ny = 32, 32
         lx, ly = 2 * np.pi, 2 * np.pi
         grid = GridInfo(
-            bounds=((0, lx), (0, ly)), shape=(nx, ny), periodic=(True, True),
+            bounds=((0, lx), (0, ly)),
+            shape=(nx, ny),
+            periodic=(True, True),
         )
         x, y = grid.coord_arrays()
 
@@ -926,7 +941,11 @@ class TestPreSolveConstraints:
         y0[a1_slot * n : (a1_slot + 1) * n] = gaussian.ravel()
 
         y0_out = pre_solve_constraints(
-            spec, grid, y0, bc="periodic", parameters={"kappa": 0.5},
+            spec,
+            grid,
+            y0,
+            bc="periodic",
+            parameters={"kappa": 0.5},
         )
 
         # A_0 should be nonzero (kappa source from A_1)
@@ -1100,7 +1119,11 @@ class TestGaugeRegularizationWarnings:
 
         with pytest.warns(UserWarning, match="singular mode"):
             pre_solve_constraints(
-                spec, grid, y0, bc="periodic", parameters={"kappa": 0.5},
+                spec,
+                grid,
+                y0,
+                bc="periodic",
+                parameters={"kappa": 0.5},
             )
 
     @pytest.mark.skipif(not _has_sundials(), reason="sksundae not available")
@@ -1528,7 +1551,9 @@ class TestNoSelfTermConstraints:
 
         spec = _make_multi_no_self_term_spec()
         grid = GridInfo(
-            bounds=((0, 10), (0, 10)), shape=(16, 16), periodic=(True, True),
+            bounds=((0, 10), (0, 10)),
+            shape=(16, 16),
+            periodic=(True, True),
         )
         layout = StateLayout.from_spec(spec, grid.num_points)
         n = grid.num_points
@@ -1732,7 +1757,9 @@ class TestEnsureConsistentIC:
         """EM-like standard constraint (enabled=True) → same as pre_solve."""
         spec = _make_em_2d_spec()
         grid = GridInfo(
-            bounds=((0, 10), (0, 10)), shape=(16, 16), periodic=(True, True),
+            bounds=((0, 10), (0, 10)),
+            shape=(16, 16),
+            periodic=(True, True),
         )
         layout = StateLayout.from_spec(spec, grid.num_points)
         n = grid.num_points
@@ -1896,7 +1923,9 @@ class TestEnsureConsistentIC:
         """EM spec: ensure_consistent_ic produces same result as pre_solve_constraints."""
         spec = _make_em_2d_spec()
         grid = GridInfo(
-            bounds=((0, 10), (0, 10)), shape=(16, 16), periodic=(True, True),
+            bounds=((0, 10), (0, 10)),
+            shape=(16, 16),
+            periodic=(True, True),
         )
         layout = StateLayout.from_spec(spec, grid.num_points)
         n = grid.num_points
@@ -1924,7 +1953,9 @@ class TestEnsureConsistentIC:
         """Chern-Simons: ensure_consistent_ic matches pre_solve_constraints."""
         spec = _make_chern_simons_spec()
         grid = GridInfo(
-            bounds=((0, 10), (0, 10)), shape=(16, 16), periodic=(True, True),
+            bounds=((0, 10), (0, 10)),
+            shape=(16, 16),
+            periodic=(True, True),
         )
         layout = StateLayout.from_spec(spec, grid.num_points)
         n = grid.num_points
@@ -2627,7 +2658,9 @@ class TestEnsureConsistentIC:
         """When multiple constraints are violated, all are listed in the error."""
         spec = _make_multi_no_self_term_spec()
         grid = GridInfo(
-            bounds=((0, 10), (0, 10)), shape=(16, 16), periodic=(True, True),
+            bounds=((0, 10), (0, 10)),
+            shape=(16, 16),
+            periodic=(True, True),
         )
         layout = StateLayout.from_spec(spec, grid.num_points)
         n = grid.num_points

--- a/tests/test_solver_fields.py
+++ b/tests/test_solver_fields.py
@@ -118,7 +118,9 @@ class TestFieldSetConstruction:
         spec = _make_kg_spec()
         layout = StateLayout.from_spec(spec, 8)
         fs = FieldSet.from_dict(
-            layout, (8,), {"phi_0": np.ones(8), "nonexistent": np.zeros(8)},
+            layout,
+            (8,),
+            {"phi_0": np.ones(8), "nonexistent": np.zeros(8)},
         )
         np.testing.assert_array_equal(fs["phi_0"], 1.0)
 

--- a/tests/test_solver_modal_unified.py
+++ b/tests/test_solver_modal_unified.py
@@ -111,7 +111,11 @@ def _make_rank_deficient_spec() -> EquationSystem:
 def _build_eval_context(
     spec: EquationSystem,
 ) -> tuple[
-    StateLayout, GridInfo, CoefficientEvaluator, list[np.ndarray], tuple[int, ...],
+    StateLayout,
+    GridInfo,
+    CoefficientEvaluator,
+    list[np.ndarray],
+    tuple[int, ...],
 ]:
     grid = GridInfo(shape=(32,), bounds=((0.0, 10.0),), periodic=(True,))
     layout = StateLayout.from_spec(spec, grid.num_points)
@@ -354,10 +358,20 @@ def test_svd_schur_continuity_through_critical_point() -> None:
     layout_c, grid_c, ce_c, kg_c, rs_c = _build_eval_context(spec_crit)
 
     A_near, _, _, _, _, _, _, _ = _build_evolution_matrices(
-        spec_near, layout_n, grid_n, ce_n, kg_n, rs_n,
+        spec_near,
+        layout_n,
+        grid_n,
+        ce_n,
+        kg_n,
+        rs_n,
     )
     A_crit, _, _, _, _, _, _, _ = _build_evolution_matrices(
-        spec_crit, layout_c, grid_c, ce_c, kg_c, rs_c,
+        spec_crit,
+        layout_c,
+        grid_c,
+        ce_c,
+        kg_c,
+        rs_c,
     )
 
     # Compare eigenvalues at a representative non-DC mode
@@ -546,10 +560,20 @@ def test_kcc_rank_deficient_pinv_continuity() -> None:
     layout_c, grid_c, ce_c, kg_c, rs_c = _build_eval_context(spec_crit)
 
     A_near, _, _, _, _, _, _, _ = _build_evolution_matrices(
-        spec_near, layout_n, grid_n, ce_n, kg_n, rs_n,
+        spec_near,
+        layout_n,
+        grid_n,
+        ce_n,
+        kg_n,
+        rs_n,
     )
     A_crit, _, _, _, _, _, _, _ = _build_evolution_matrices(
-        spec_crit, layout_c, grid_c, ce_c, kg_c, rs_c,
+        spec_crit,
+        layout_c,
+        grid_c,
+        ce_c,
+        kg_c,
+        rs_c,
     )
 
     m_idx = 2
@@ -569,10 +593,12 @@ def test_kcc_rank_deficient_pinv_continuity() -> None:
 
     # Physical eigenvalues (|λ| > 0.01) should be continuous
     phys_near: list[complex] = sorted(
-        w_near[np.abs(w_near) > 0.01], key=lambda z: -abs(z.imag),
+        w_near[np.abs(w_near) > 0.01],
+        key=lambda z: -abs(z.imag),
     )
     phys_crit: list[complex] = sorted(
-        w_crit[np.abs(w_crit) > 0.01], key=lambda z: -abs(z.imag),
+        w_crit[np.abs(w_crit) > 0.01],
+        key=lambda z: -abs(z.imag),
     )
 
     if phys_near and phys_crit:

--- a/tests/test_solver_operators.py
+++ b/tests/test_solver_operators.py
@@ -99,21 +99,24 @@ class TestOperatorsPeriodic2D:
         return g, data, xs, ys
 
     def test_gradient_x(
-        self, setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
+        self,
+        setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
     ) -> None:
         g, data, xs, ys = setup
         result = gradient(data, 0, g)
         np.testing.assert_allclose(result, np.cos(xs) * np.cos(ys), atol=5e-3)
 
     def test_gradient_y(
-        self, setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
+        self,
+        setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
     ) -> None:
         g, data, xs, ys = setup
         result = gradient(data, 1, g)
         np.testing.assert_allclose(result, -np.sin(xs) * np.sin(ys), atol=5e-3)
 
     def test_laplacian(
-        self, setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
+        self,
+        setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
     ) -> None:
         g, data, _xs, _ys = setup
         result = laplacian(data, g)
@@ -121,14 +124,16 @@ class TestOperatorsPeriodic2D:
         np.testing.assert_allclose(result, -2 * data, atol=5e-2)
 
     def test_directional_laplacian_x(
-        self, setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
+        self,
+        setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
     ) -> None:
         g, data, xs, ys = setup
         result = directional_laplacian(data, 0, g)
         np.testing.assert_allclose(result, -np.sin(xs) * np.cos(ys), atol=5e-3)
 
     def test_cross_derivative(
-        self, setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
+        self,
+        setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
     ) -> None:
         g, data, xs, ys = setup
         result = cross_derivative(data, 0, 1, g)
@@ -136,7 +141,8 @@ class TestOperatorsPeriodic2D:
         np.testing.assert_allclose(result, -np.cos(xs) * np.sin(ys), atol=5e-2)
 
     def test_biharmonic(
-        self, setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
+        self,
+        setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
     ) -> None:
         g, data, _xs, _ys = setup
         result = biharmonic(data, g)
@@ -144,7 +150,8 @@ class TestOperatorsPeriodic2D:
         np.testing.assert_allclose(result, 4 * data, atol=0.5)
 
     def test_identity(
-        self, setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
+        self,
+        setup: tuple[GridInfo, np.ndarray, np.ndarray, np.ndarray],
     ) -> None:
         g, data, _, _ = setup
         result = identity(data, g)
@@ -543,7 +550,10 @@ class TestAxisBCSpecWithOperators:
         result_str = directional_laplacian(data, 0, g, bc="neumann")
         side = SideBCSpec(kind="neumann")
         result_spec = directional_laplacian(
-            data, 0, g, bc=(AxisBCSpec(periodic=False, low=side, high=side),),
+            data,
+            0,
+            g,
+            bc=(AxisBCSpec(periodic=False, low=side, high=side),),
         )
         np.testing.assert_allclose(result_spec, result_str, atol=1e-14)
 
@@ -556,7 +566,10 @@ class TestAxisBCSpecWithOperators:
         result_str = directional_laplacian(data, 0, g, bc="dirichlet")
         side = SideBCSpec(kind="dirichlet")
         result_spec = directional_laplacian(
-            data, 0, g, bc=(AxisBCSpec(periodic=False, low=side, high=side),),
+            data,
+            0,
+            g,
+            bc=(AxisBCSpec(periodic=False, low=side, high=side),),
         )
         np.testing.assert_allclose(result_spec, result_str, atol=1e-14)
 

--- a/tests/test_solver_sparsity.py
+++ b/tests/test_solver_sparsity.py
@@ -213,7 +213,9 @@ class TestBuildJacobianSparsity:
         """EM 2D pattern should be very sparse."""
         spec = _make_em_2d_spec()
         grid = GridInfo(
-            bounds=((0, 10), (0, 10)), shape=(16, 16), periodic=(True, True),
+            bounds=((0, 10), (0, 10)),
+            shape=(16, 16),
+            periodic=(True, True),
         )
         layout = StateLayout.from_spec(spec, grid.num_points)
 

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -270,7 +270,12 @@ class TestProbePerformance:
         return _load_t1()
 
     def test_probe_perf(self, t1: tuple[EquationSystem, GridInfo]) -> None:
-        """Median probe wall ≤ 6 ms over 1000 random param dicts (T1, N=32)."""
+        """Probe wall stays within the recorded budget (T1, N=32).
+
+        Guard only -- the asserted budget below is the operative number.
+        Wall-clock here is load-sensitive, so this catches gross regressions
+        rather than pinning a precise figure.
+        """
         spec, grid = t1
 
         rng = np.random.default_rng(0)
@@ -311,13 +316,14 @@ class TestProbePerformance:
         #  * Phases 1-2 (commit 350b53b et al.): per-process spec cache
         #    + parameter-independent structural cache for the probe
         #    saved ~2 ms/call.
-        #  * Phase 3 (commit XXXXXXX): ``np.einsum`` → ``np.matmul``
+        #  * Phase 3 (commit 49c9d447): ``np.einsum`` → ``np.matmul``
         #    refactor inside ``_build_evolution_matrices``.  Batched
         #    3-D matmul dispatches to BLAS gemm; the 3-way einsums
         #    that replicated ``(U @ K) @ V`` were ~70× slower without
         #    ``optimize=True``.  Saved ~12 ms/call.
         #
-        # Combined: median dropped from ≈ 27.6 ms → ≈ 13 ms (2.13×).
+        # Combined, as measured at the time: ≈ 27.6 ms → ≈ 13 ms (2.13×).
+        # (Historical -- superseded by the post-#341 figure below.)
         #
         # Post-#341 (threshold 0.30 → 0.15): the spectral-radius
         # prefilter cutoff is ``threshold * t_test`` so dropping the

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -317,7 +317,9 @@ class TestSweepResults:
         assert len(data["rows"]) == 3
 
     def test_save_sweep_json(
-        self, sample_results: SweepResults, tmp_path: Path,
+        self,
+        sample_results: SweepResults,
+        tmp_path: Path,
     ) -> None:
         sweep_file = tmp_path / "sweep.json"
         sample_results.save_sweep_json(sweep_file)
@@ -328,7 +330,9 @@ class TestSweepResults:
         assert data["completed_runs"] == 3
 
     def test_save_sweep_json_includes_run_dirs(
-        self, sample_results: SweepResults, tmp_path: Path,
+        self,
+        sample_results: SweepResults,
+        tmp_path: Path,
     ) -> None:
         sweep_file = tmp_path / "sweep.json"
         sample_results.save_sweep_json(sweep_file)
@@ -651,7 +655,8 @@ class TestRunStatusTracking:
         assert all(r["run_status"] != "success" for r in f.rows)
 
     def test_successful_rows_preserves_run_dirs(
-        self, mixed_results: SweepResults,
+        self,
+        mixed_results: SweepResults,
     ) -> None:
         s = mixed_results.successful_rows()
         assert len(s.run_dirs) == 2
@@ -1109,7 +1114,9 @@ class TestSweepValidation:
         assert code == 1
 
     def test_unknown_swept_param_warns(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         """Swept param not in spec should warn but not error."""
         from tidal.cli import main
@@ -1402,7 +1409,10 @@ class TestSweepPlotOverlay:
         results = _make_1d_sweep_results()
         fig, ax = plt.subplots()
         render_sweep_1d(
-            ax, results, "P_final", overlay="sin(kappa * B0 * t_end / 2)**2",
+            ax,
+            results,
+            "P_final",
+            overlay="sin(kappa * B0 * t_end / 2)**2",
         )
 
         lines = ax.get_lines()
@@ -1454,7 +1464,10 @@ class TestSweepPlotOverlay:
         results = _make_1d_sweep_results()
         fig, ax = plt.subplots()
         render_sweep_1d(
-            ax, results, "P_final", overlay="sin(kappa * B0 * t_end / 2)**2",
+            ax,
+            results,
+            "P_final",
+            overlay="sin(kappa * B0 * t_end / 2)**2",
         )
 
         # The second line is the overlay
@@ -1481,7 +1494,10 @@ class TestSweepPlotOverlay:
         results = _make_2d_sweep_results()
         fig = plt.figure(figsize=(15, 5))
         render_sweep_2d_with_overlay(
-            fig, results, "P_final", "sin(kappa * Bpeak * R * sqrt(pi/2))**2",
+            fig,
+            results,
+            "P_final",
+            "sin(kappa * Bpeak * R * sqrt(pi/2))**2",
         )
 
         assert len(fig.axes) >= 3
@@ -1499,7 +1515,10 @@ class TestSweepPlotOverlay:
         results = _make_2d_sweep_results()
         fig = plt.figure(figsize=(15, 5))
         render_sweep_2d_with_overlay(
-            fig, results, "P_final", "sin(kappa * Bpeak * R * sqrt(pi/2))**2",
+            fig,
+            results,
+            "P_final",
+            "sin(kappa * Bpeak * R * sqrt(pi/2))**2",
         )
 
         # The third pcolormesh (error panel) should have near-zero values

--- a/tests/test_sweep_config.py
+++ b/tests/test_sweep_config.py
@@ -27,7 +27,8 @@ class TestParseSweepSection:
 
     def test_linear_range(self) -> None:
         values, adaptive = _parse_sweep_section(
-            "g0", {"start": 0.1, "stop": 1.0, "count": 5},
+            "g0",
+            {"start": 0.1, "stop": 1.0, "count": 5},
         )
         assert len(values) == 5
         assert values[0] == pytest.approx(0.1)
@@ -80,13 +81,15 @@ class TestParseSweepSection:
     def test_log_negative_bounds(self) -> None:
         with pytest.raises(ValueError, match="positive bounds"):
             _parse_sweep_section(
-                "g0", {"start": -1.0, "stop": 1.0, "count": 5, "scale": "log"},
+                "g0",
+                {"start": -1.0, "stop": 1.0, "count": 5, "scale": "log"},
             )
 
     def test_unknown_scale(self) -> None:
         with pytest.raises(ValueError, match="unknown scale"):
             _parse_sweep_section(
-                "g0", {"start": 0.0, "stop": 1.0, "count": 5, "scale": "cubic"},
+                "g0",
+                {"start": 0.0, "stop": 1.0, "count": 5, "scale": "cubic"},
             )
 
     def test_explicit_values_too_few(self) -> None:
@@ -223,7 +226,9 @@ class TestLoadSweepConfig:
         assert config.output == subdir / ".." / "results"
 
     def test_unknown_sections_warn(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         toml = tmp_path / "sweep.toml"
         spec = tmp_path / "spec.json"

--- a/tests/test_sweep_replicates.py
+++ b/tests/test_sweep_replicates.py
@@ -80,7 +80,10 @@ class TestExpandReplicates:
     def test_basic_expansion(self) -> None:
         plans = [_make_plan()]
         expanded = _expand_replicates(
-            plans, n_replicates=3, base_seed=42, param_noise={},
+            plans,
+            n_replicates=3,
+            base_seed=42,
+            param_noise={},
         )
         assert len(expanded) == 3
         for i, rp in enumerate(expanded):
@@ -99,7 +102,10 @@ class TestExpandReplicates:
         plans[1]["run_dir"] = Path("/tmp/test/g0_2")
         plans[1]["index"] = 1
         expanded = _expand_replicates(
-            plans, n_replicates=2, base_seed=0, param_noise={},
+            plans,
+            n_replicates=2,
+            base_seed=0,
+            param_noise={},
         )
         assert len(expanded) == 4
         # First two should be replicates of point 1
@@ -126,7 +132,10 @@ class TestExpandReplicates:
             p["subdir"] = f"g0_{int(p['swept_vals']['g0'])}"
             p["run_dir"] = Path(f"/tmp/test/{p['subdir']}")
         expanded = _expand_replicates(
-            plans, n_replicates=2, base_seed=10, param_noise={},
+            plans,
+            n_replicates=2,
+            base_seed=10,
+            param_noise={},
         )
         indices = [rp["index"] for rp in expanded]
         assert indices == list(range(6))
@@ -143,7 +152,10 @@ class TestParamNoise:
     def test_noise_applied(self) -> None:
         plans = [_make_plan({"g0": 1.0}, {"g0": 1.0})]
         expanded = _expand_replicates(
-            plans, n_replicates=5, base_seed=42, param_noise={"g0": 0.1},
+            plans,
+            n_replicates=5,
+            base_seed=42,
+            param_noise={"g0": 0.1},
         )
         # Each replicate should have a different g0 value
         g0_vals = [rp["swept_vals"]["g0"] for rp in expanded]
@@ -156,7 +168,10 @@ class TestParamNoise:
     def test_nominal_vals_stored(self) -> None:
         plans = [_make_plan({"g0": 1.0}, {"g0": 1.0})]
         expanded = _expand_replicates(
-            plans, n_replicates=3, base_seed=42, param_noise={"g0": 0.1},
+            plans,
+            n_replicates=3,
+            base_seed=42,
+            param_noise={"g0": 0.1},
         )
         for rp in expanded:
             assert rp["nominal_vals"] == {"g0": 1.0}
@@ -164,10 +179,16 @@ class TestParamNoise:
     def test_noise_deterministic(self) -> None:
         plans = [_make_plan({"g0": 1.0}, {"g0": 1.0})]
         exp1 = _expand_replicates(
-            plans, n_replicates=3, base_seed=42, param_noise={"g0": 0.1},
+            plans,
+            n_replicates=3,
+            base_seed=42,
+            param_noise={"g0": 0.1},
         )
         exp2 = _expand_replicates(
-            plans, n_replicates=3, base_seed=42, param_noise={"g0": 0.1},
+            plans,
+            n_replicates=3,
+            base_seed=42,
+            param_noise={"g0": 0.1},
         )
         for a, b in zip(exp1, exp2, strict=True):
             assert a["swept_vals"]["g0"] == b["swept_vals"]["g0"]
@@ -175,7 +196,10 @@ class TestParamNoise:
     def test_noise_not_applied_when_empty(self) -> None:
         plans = [_make_plan({"g0": 1.0}, {"g0": 1.0})]
         expanded = _expand_replicates(
-            plans, n_replicates=3, base_seed=42, param_noise={},
+            plans,
+            n_replicates=3,
+            base_seed=42,
+            param_noise={},
         )
         for rp in expanded:
             assert rp["swept_vals"]["g0"] == 1.0
@@ -588,13 +612,19 @@ class TestParamNoiseRNGIndependence:
 
         # With only g0 noise
         exp_g0_only = _expand_replicates(
-            plans, n_replicates=3, base_seed=42, param_noise={"g0": 0.1},
+            plans,
+            n_replicates=3,
+            base_seed=42,
+            param_noise={"g0": 0.1},
         )
         g0_vals_only = [rp["swept_vals"]["g0"] for rp in exp_g0_only]
 
         # With both g0 and m2 noise
         exp_both = _expand_replicates(
-            plans, n_replicates=3, base_seed=42, param_noise={"g0": 0.1, "m2": 0.05},
+            plans,
+            n_replicates=3,
+            base_seed=42,
+            param_noise={"g0": 0.1, "m2": 0.05},
         )
         g0_vals_both = [rp["swept_vals"]["g0"] for rp in exp_both]
 

--- a/tests/test_velocity_resonance.py
+++ b/tests/test_velocity_resonance.py
@@ -236,7 +236,10 @@ class TestResonanceAnalysis:
         """Very different masses should give fewer resonant modes."""
         data = _make_two_field_wave_data(m2_phi=0.1, m2_chi=10.0)
         result = compute_resonance_analysis(
-            data, "phi_0", "chi_0", resonance_threshold=0.05,
+            data,
+            "phi_0",
+            "chi_0",
+            resonance_threshold=0.05,
         )
         # Very different mass -> large frequency mismatch -> fewer resonant
         assert isinstance(result, ResonanceResult)

--- a/tidal/banner.py
+++ b/tidal/banner.py
@@ -142,7 +142,9 @@ def _supports_color() -> bool:
 
 
 def _lerp(
-    a: tuple[int, int, int], b: tuple[int, int, int], t: float,
+    a: tuple[int, int, int],
+    b: tuple[int, int, int],
+    t: float,
 ) -> tuple[int, int, int]:
     return (
         int(a[0] + (b[0] - a[0]) * t),
@@ -152,7 +154,9 @@ def _lerp(
 
 
 def _gradient_row(
-    idx: int, total: int, stops: list[tuple[int, int, int]],
+    idx: int,
+    total: int,
+    stops: list[tuple[int, int, int]],
 ) -> tuple[int, int, int]:
     if not stops or total <= 1:
         return (200, 200, 200)
@@ -250,7 +254,9 @@ if __name__ == "__main__":
     p = argparse.ArgumentParser(description="Preview TIDAL CLI banner")
     p.add_argument("--theme", choices=list(THEMES.keys()), default="ocean")
     p.add_argument(
-        "--layout", choices=["compact", "stacked", "minimal", "auto"], default="auto",
+        "--layout",
+        choices=["compact", "stacked", "minimal", "auto"],
+        default="auto",
     )
     a = p.parse_args()
     print_banner(theme=a.theme, layout=a.layout, file=sys.stdout)

--- a/tidal/cli/__init__.py
+++ b/tidal/cli/__init__.py
@@ -688,9 +688,10 @@ def _build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
         action="store_true",
         default=False,
         help=(
-            "Run stability checks: tachyon detection (negative mass-matrix eigenvalues) "
-            "and ghost detection (wrong-sign kinetic terms from Hamiltonian). "
-            "Uses a 1-point grid; exact for constant-coefficient systems."
+            "Run stability checks: tachyon detection (negative mass-matrix "
+            "eigenvalues). Uses a 1-point grid; exact for constant-coefficient "
+            "systems. Ghost detection is not included -- Hamiltonian kinetic "
+            "coefficients alone cannot distinguish ghosts from gauge structure."
         ),
     )
     validate_parser.add_argument(
@@ -1994,7 +1995,7 @@ def _build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
             "(default: -100). For baseline-normalized maximize/minimize runs the "
             "natural physics logL is near 0, so -100 drags logZ to -100 and makes "
             "the PolyChord precision criterion unreachable. Use -15 (or similar) "
-            "to keep logZ in a sensible range. See issue #372."
+            "to keep logZ in a sensible range. See issue #375."
         ),
     )
     # Sampling method

--- a/tidal/cli/_derive_validate.py
+++ b/tidal/cli/_derive_validate.py
@@ -531,7 +531,9 @@ def _validate_linearization(
 
     if matter_perts:
         _validate_matter_perturbations(
-            config, matter_perts, has_lagrangian=has_lagrangian,
+            config,
+            matter_perts,
+            has_lagrangian=has_lagrangian,
         )
 
 

--- a/tidal/cli/_inspect.py
+++ b/tidal/cli/_inspect.py
@@ -351,10 +351,14 @@ def _print_equations(spec: object, *, detail: str = "full") -> None:
         )
         for eq in spec.equations:
             kind = "dynamical" if eq.time_derivative_order > 0 else "constraint"
-            print(f"  {eq.field_name:<12s} {kind:<12s} time_order={eq.time_derivative_order}")
+            print(
+                f"  {eq.field_name:<12s} {kind:<12s} time_order={eq.time_derivative_order}"
+            )
         print()
 
-    print("Equations:" if detail != "summary" else "Signs (proven only; ? = undecided):")
+    print(
+        "Equations:" if detail != "summary" else "Signs (proven only; ? = undecided):"
+    )
     for eq in spec.equations:
         for line in _render_equation(eq, summary=detail == "summary"):
             print(line)

--- a/tidal/cli/_inspect_query.py
+++ b/tidal/cli/_inspect_query.py
@@ -141,10 +141,17 @@ def show_equation(  # noqa: PLR0913
     records: list[dict[str, Any]] = []
     text: list[str] = []
     for name in requested:
-        text.extend(_equation_lines(spec, name, records, as_json=as_json,
-                                    parameters=parameters,
-                                    assume_positive=assume_positive,
-                                    assume_nonzero=assume_nonzero))
+        text.extend(
+            _equation_lines(
+                spec,
+                name,
+                records,
+                as_json=as_json,
+                parameters=parameters,
+                assume_positive=assume_positive,
+                assume_nonzero=assume_nonzero,
+            )
+        )
 
     if as_json:
         print(json.dumps({"items": [_project(r, fields) for r in records]}, indent=2))

--- a/tidal/cli/_list.py
+++ b/tidal/cli/_list.py
@@ -41,15 +41,32 @@ def list_command(args: Namespace) -> int:
     from tidal.cli._inspect import discover_parameters
     from tidal.symbolic.json_loader import load_equation_system
 
-    scan_dir = Path(args.dir) if args.dir else _find_examples_dir()
+    explicit_dir = args.dir is not None
+    scan_dir = Path(args.dir) if explicit_dir else _find_examples_dir()
 
     if not scan_dir.is_dir():
         from tidal.cli._console import error_with_hint
 
-        error_with_hint(
-            f"directory not found: {scan_dir}",
-            hints=["Default: examples/data/. Override with positional arg."],
-        )
+        if explicit_dir:
+            error_with_hint(
+                f"directory not found: {scan_dir}",
+                hints=["Check the path given to --dir."],
+            )
+        else:
+            # Neither the cwd nor the package parent holds examples/data.
+            # The usual cause is an installed wheel: the distribution ships
+            # only the ``tidal`` package, so the example specs are absent
+            # (see [tool.setuptools.packages.find] in pyproject.toml).
+            error_with_hint(
+                "no examples directory found",
+                hints=[
+                    "The example specs ship with the repository, not with the "
+                    "installed package.",
+                    "Clone it and run from the checkout: "
+                    "git clone https://github.com/WilliamRoyce/tidal",
+                    "Or scan your own specs: tidal list --dir PATH",
+                ],
+            )
         return 1
 
     json_files = sorted(scan_dir.glob("*.json"))

--- a/tidal/cli/_measure.py
+++ b/tidal/cli/_measure.py
@@ -284,7 +284,10 @@ def _run_conversion(
     )
 
     source, target = _resolve_source_target(
-        data, source, target, measurement_name="conversion",
+        data,
+        source,
+        target,
+        measurement_name="conversion",
     )
 
     # Single-field or group conversion
@@ -329,10 +332,14 @@ def _run_spectrum(data: SimulationData) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for name in data.fields:
         snap_initial = compute_spectrum(
-            data.fields[name][0], data.grid_spacing, data.periodic,
+            data.fields[name][0],
+            data.grid_spacing,
+            data.periodic,
         )
         snap_final = compute_spectrum(
-            data.fields[name][-1], data.grid_spacing, data.periodic,
+            data.fields[name][-1],
+            data.grid_spacing,
+            data.periodic,
         )
         result[name] = {
             "initial": {
@@ -405,7 +412,10 @@ def _run_asymptotic(
     from tidal.measurement import compute_asymptotic_conversion
 
     source, target = _resolve_source_target(
-        data, source, target, measurement_name="asymptotic",
+        data,
+        source,
+        target,
+        measurement_name="asymptotic",
     )
 
     result = compute_asymptotic_conversion(data, list(source), list(target))
@@ -467,7 +477,11 @@ def _run_velocity_mismatch(
     from tidal.measurement import compute_velocity_mismatch
 
     source, target = _resolve_source_target(
-        data, source, target, require_both=True, measurement_name="velocity mismatch",
+        data,
+        source,
+        target,
+        require_both=True,
+        measurement_name="velocity mismatch",
     )
 
     result = compute_velocity_mismatch(data, list(source), list(target))
@@ -491,7 +505,11 @@ def _run_resonance(
     from tidal.measurement import compute_resonance_analysis
 
     source, target = _resolve_source_target(
-        data, source, target, require_both=True, measurement_name="resonance",
+        data,
+        source,
+        target,
+        require_both=True,
+        measurement_name="resonance",
     )
 
     result = compute_resonance_analysis(data, list(source), list(target))
@@ -842,7 +860,9 @@ def _run_individual_measurements(  # noqa: C901, PLR0912
 
     if "conservation" in measurements:
         results["conservation"] = _run_measurement_safe(
-            _run_conservation, data, threshold,
+            _run_conservation,
+            data,
+            threshold,
         )
 
     if "conversion" in measurements or "mixing" in measurements:
@@ -872,23 +892,33 @@ def _run_individual_measurements(  # noqa: C901, PLR0912
             )
             return 1
         results["dispersion"] = _run_measurement_safe(
-            _run_dispersion, data, dyn_in_source,
+            _run_dispersion,
+            data,
+            dyn_in_source,
         )
 
     if "effective_mass" in measurements:
         dyn_in_source = _filter_to_dynamical(source, data, "effective_mass")
         results["effective_mass"] = _run_measurement_safe(
-            _run_effective_mass, data, dyn_in_source,
+            _run_effective_mass,
+            data,
+            dyn_in_source,
         )
 
     if "asymptotic" in measurements:
         results["asymptotic"] = _run_measurement_safe(
-            _run_asymptotic, data, source, target,
+            _run_asymptotic,
+            data,
+            source,
+            target,
         )
 
     if "peak_conversion" in measurements:
         results["peak_conversion"] = _run_measurement_safe(
-            _run_peak_conversion, data, source, target,
+            _run_peak_conversion,
+            data,
+            source,
+            target,
         )
 
     if "velocity" in measurements:
@@ -896,12 +926,18 @@ def _run_individual_measurements(  # noqa: C901, PLR0912
         results["velocity"] = _run_measurement_safe(_run_velocity, data, dyn_in_source)
         if "error" not in results["velocity"] and target is not None:
             results["velocity_mismatch"] = _run_measurement_safe(
-                _run_velocity_mismatch, data, tuple(dyn_in_source), target,
+                _run_velocity_mismatch,
+                data,
+                tuple(dyn_in_source),
+                target,
             )
 
     if "resonance" in measurements:
         results["resonance"] = _run_measurement_safe(
-            _run_resonance, data, source, target,
+            _run_resonance,
+            data,
+            source,
+            target,
         )
 
     return results

--- a/tidal/cli/_measure_plot.py
+++ b/tidal/cli/_measure_plot.py
@@ -80,7 +80,12 @@ def _plot_energy(ax: Axes, results: dict[str, Any]) -> None:
     for name, series in eng["per_field"].items():
         ax.plot(times, series, label=name, linewidth=1.2)
     ax.plot(
-        times, eng["interaction"], "--", label="interaction", linewidth=1.0, alpha=0.7,
+        times,
+        eng["interaction"],
+        "--",
+        label="interaction",
+        linewidth=1.0,
+        alpha=0.7,
     )
     ax.plot(times, eng["total"], "k-", label="total", linewidth=1.0, alpha=0.5)
     ax.legend(fontsize=7, ncol=2)

--- a/tidal/cli/_report.py
+++ b/tidal/cli/_report.py
@@ -38,7 +38,10 @@ def _make_overview_plot(sim_data: SimulationData, grid_info: GridInfo) -> str:
 
     n_fields = len(sim_data.fields)
     fig, axes = plt.subplots(
-        1, max(n_fields, 1), figsize=(5 * n_fields, 4), squeeze=False,
+        1,
+        max(n_fields, 1),
+        figsize=(5 * n_fields, 4),
+        squeeze=False,
     )
 
     for i, (name, data) in enumerate(sim_data.fields.items()):

--- a/tidal/cli/_sweep_config.py
+++ b/tidal/cli/_sweep_config.py
@@ -207,7 +207,8 @@ def _parse_range(
             )
             raise ValueError(msg)
         return cast(
-            "list[float]", np.logspace(np.log10(start), np.log10(stop), count).tolist(),
+            "list[float]",
+            np.logspace(np.log10(start), np.log10(stop), count).tolist(),
         ), {}
     msg = f"[sweep.{name}] unknown scale '{scale}' (expected: linear, log, adaptive)"
     raise ValueError(msg)
@@ -243,7 +244,9 @@ def _parse_sweeps(
             if not isinstance(section, dict):
                 continue
             values, ac = _parse_sweep_section(
-                name, cast("dict[str, Any]", section), strategy=strategy,
+                name,
+                cast("dict[str, Any]", section),
+                strategy=strategy,
             )
             swept[name] = values
             if ac:

--- a/tidal/cli/_validate.py
+++ b/tidal/cli/_validate.py
@@ -509,7 +509,8 @@ def validate_command(args: Namespace) -> int:
     errors.extend(pert_errors)
     warnings.extend(pert_warnings)
 
-    # Check 6: Stability — tachyon and ghost mode detection
+    # Check 6: Stability — tachyon detection (see _run_stability_checks:
+    # ghost detection is deliberately not attempted here)
     if getattr(args, "stability", False):
         from tidal.symbolic.json_loader import EquationSystem
 

--- a/tidal/cli/_wls_helpers.py
+++ b/tidal/cli/_wls_helpers.py
@@ -73,7 +73,9 @@ def wl_skip_tuples(dim: int) -> str:
 def wl_bg_rule_entry(head: str, comps: str, contra: str) -> str:
     """BackgroundFieldRules entry: ``{head, {comps}, {contra}}``."""
     return wl_list(
-        head, wl_list(comps) if comps else "{}", wl_list(contra) if contra else "{}",
+        head,
+        wl_list(comps) if comps else "{}",
+        wl_list(contra) if contra else "{}",
     )
 
 

--- a/tidal/inference/_likelihood.py
+++ b/tidal/inference/_likelihood.py
@@ -56,7 +56,7 @@ def _soft_floor_logl(
     tests via ``--soft-floor-noise=0``).  The floor defaults to
     ``SOFT_FLOOR_LOGL`` but can be overridden per-run via
     ``--soft-floor-logl`` when the default -100 contaminates logZ for
-    baseline-normalized likelihoods (see issue #372).
+    baseline-normalized likelihoods (see issue #375).
     """
     if sigma_explore <= 0.0:
         return floor
@@ -110,7 +110,7 @@ class LikelihoodConfig:
     to -100 and makes the PolyChord precision criterion unreachable.  Use
     ``--soft-floor-logl -15`` (or similar) to keep logZ in a sensible range
     so that ``precision_criterion × |logZ|`` stays achievable.
-    See issue #372."""
+    See issue #375."""
 
     def __post_init__(self) -> None:
         valid = {"gaussian", "threshold", "maximize", "minimize", "extremize"}

--- a/tidal/measurement/_asymptotic.py
+++ b/tidal/measurement/_asymptotic.py
@@ -116,7 +116,8 @@ def _build_k_grids(
     for ax in range(ndim):
         n = field_shape[ax]
         k_ax: NDArray[np.float64] = np.asarray(
-            np.fft.fftfreq(n, d=grid_spacing[ax]) * (2.0 * np.pi), dtype=np.float64,
+            np.fft.fftfreq(n, d=grid_spacing[ax]) * (2.0 * np.pi),
+            dtype=np.float64,
         )
         k_arrays.append(k_ax)
     return [

--- a/tidal/measurement/_critical_field.py
+++ b/tidal/measurement/_critical_field.py
@@ -252,7 +252,11 @@ def _process_group(  # noqa: PLR0913, PLR0914, PLR0917
 
     # Error: interpolation model (quadratic vs linear)
     err_interp = _interpolation_model_error(
-        b_vals, m_vals, crossing_idx, threshold, b_min,
+        b_vals,
+        m_vals,
+        crossing_idx,
+        threshold,
+        b_min,
     )
 
     # Combined error (metric error requires replicate data, not available here)

--- a/tidal/measurement/_dispersion.py
+++ b/tidal/measurement/_dispersion.py
@@ -144,7 +144,10 @@ def _bin_and_detect(  # noqa: PLR0913, PLR0917
     grid_spacing: tuple[float, ...],
     min_amplitude: float,
 ) -> tuple[
-    NDArray[np.float64], NDArray[np.float64], NDArray[np.float64], NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
 ]:
     """Radially bin S(k, omega) and detect peaks.
 
@@ -275,7 +278,8 @@ def compute_dispersion(  # noqa: PLR0914
     # First field: seed the accumulators
     first_snapshots = data.fields[names[0]]
     angular_freqs, first_sfft, spacetime_power_total = _spacetime_fft(
-        first_snapshots, dt,
+        first_snapshots,
+        dt,
     )
     spatial_amp_sum = np.abs(first_sfft)
     grid_shape = first_snapshots.shape[1:]

--- a/tidal/measurement/_sensitivity.py
+++ b/tidal/measurement/_sensitivity.py
@@ -177,7 +177,10 @@ def compute_sobol_indices(
 
     try:
         si = sobol_analyze.analyze(  # type: ignore[reportUnknownVariableType]
-            problem, y, calc_second_order=False, num_resamples=n_bootstrap,
+            problem,
+            y,
+            calc_second_order=False,
+            num_resamples=n_bootstrap,
         )
     except RuntimeError as exc:
         msg = (

--- a/tidal/measurement/_spectral.py
+++ b/tidal/measurement/_spectral.py
@@ -93,7 +93,8 @@ def _build_k_grid(
         dx = grid_spacing[axis]
         if axis == ndim - 1:
             freq = np.asarray(
-                np.fft.rfftfreq(n, d=dx) * (2.0 * np.pi), dtype=np.float64,
+                np.fft.rfftfreq(n, d=dx) * (2.0 * np.pi),
+                dtype=np.float64,
             )
         else:
             freq = np.asarray(np.fft.fftfreq(n, d=dx) * (2.0 * np.pi), dtype=np.float64)

--- a/tidal/measurement/_writer.py
+++ b/tidal/measurement/_writer.py
@@ -176,7 +176,8 @@ class SnapshotWriter:
         # Pre-allocate per-field .npy files
         snapshot_shape = (n_snapshots, *grid_shape)
         self._field_mmaps: dict[
-            str, np.memmap[tuple[int, ...], np.dtype[np.float64]],
+            str,
+            np.memmap[tuple[int, ...], np.dtype[np.float64]],
         ] = {}
         for name in field_names:
             self._field_mmaps[name] = _open_memmap(
@@ -186,7 +187,8 @@ class SnapshotWriter:
 
         # Pre-allocate per-velocity .npy files
         self._velocity_mmaps: dict[
-            str, np.memmap[tuple[int, ...], np.dtype[np.float64]],
+            str,
+            np.memmap[tuple[int, ...], np.dtype[np.float64]],
         ] = {}
         for name in velocity_names:
             self._velocity_mmaps[name] = _open_memmap(

--- a/tidal/solver/_kinetic.py
+++ b/tidal/solver/_kinetic.py
@@ -191,11 +191,13 @@ def velocity_row_scale(
     -------
     float | NDArray[np.float64]
         Multiplicative factor to apply to every velocity-row contribution
-        for ``field_name``. ``1.0`` for the no-op path. Modal solver paths
-        that pre-build complex per-mode matrices may receive an array here
-        and need to either reduce it (e.g. take ``.ravel()[0]`` for the
-        constant-coefficient approximation) or fail loudly — see
-        ``modal.py:732`` for the current per-mode-Padé behavior.
+        for ``field_name``. ``1.0`` for the no-op path.
+
+        An array is only ever returned when ``grid`` is supplied, which
+        builds the ``coord_arrays`` the expression needs (GH #382).  The
+        four time-domain backends do this; the modal builders currently do
+        not, so a position-dependent kinetic reaching them raises rather
+        than being silently reduced — see GH #421.
 
     See Also
     --------

--- a/tidal/solver/analytical_jacobian.py
+++ b/tidal/solver/analytical_jacobian.py
@@ -206,7 +206,9 @@ class _OperatorCache:
             return self.get_identity()
         if operator not in self._cache:
             self._cache[operator] = build_operator_matrix(
-                operator, self._grid, self._bc,
+                operator,
+                self._grid,
+                self._bc,
             )
         return self._cache[operator]
 

--- a/tidal/solver/constraint_solve.py
+++ b/tidal/solver/constraint_solve.py
@@ -802,14 +802,20 @@ def _solve_coupled(  # noqa: PLR0912, PLR0913, PLR0914, PLR0917, C901
             methods[terms.field_name] = method
             if method != "fft":
                 op_matrices[terms.field_name] = _probe_operator_matrix(
-                    terms.self_terms, grid, bc,
+                    terms.self_terms,
+                    grid,
+                    bc,
                 )
 
         for _iteration in range(max_iter):
             max_change = 0.0
             for terms in groups:
                 source = _evaluate_source(
-                    terms.source_terms, fields, grid, bc, name_map,
+                    terms.source_terms,
+                    fields,
+                    grid,
+                    bc,
+                    name_map,
                 )
                 method = methods[terms.field_name]
 

--- a/tidal/solver/operators.py
+++ b/tidal/solver/operators.py
@@ -564,7 +564,10 @@ class _PadBufferCache:
         self._cache.clear()
 
     def get(
-        self, data_shape: tuple[int, ...], axis: int, ng: int | None = None,
+        self,
+        data_shape: tuple[int, ...],
+        axis: int,
+        ng: int | None = None,
     ) -> _PadEntry:
         if ng is None:
             ng = _n_ghost
@@ -643,11 +646,15 @@ def _pad_axis(
             left_ghost_slc = entry.left_slcs[left_ghost_idx]
             if k == 0:
                 np.multiply(
-                    f_lo, data[entry.recursive_left_src[0]], out=buf[left_ghost_slc],
+                    f_lo,
+                    data[entry.recursive_left_src[0]],
+                    out=buf[left_ghost_slc],
                 )
             else:
                 np.multiply(
-                    f_lo, buf[entry.recursive_left_src[k]], out=buf[left_ghost_slc],
+                    f_lo,
+                    buf[entry.recursive_left_src[k]],
+                    out=buf[left_ghost_slc],
                 )
             if c_lo != 0.0:
                 buf[left_ghost_slc] += c_lo
@@ -656,11 +663,15 @@ def _pad_axis(
             right_ghost_slc = entry.right_slcs[right_ghost_idx]
             if k == 0:
                 np.multiply(
-                    f_hi, data[entry.recursive_right_src[0]], out=buf[right_ghost_slc],
+                    f_hi,
+                    data[entry.recursive_right_src[0]],
+                    out=buf[right_ghost_slc],
                 )
             else:
                 np.multiply(
-                    f_hi, buf[entry.recursive_right_src[k]], out=buf[right_ghost_slc],
+                    f_hi,
+                    buf[entry.recursive_right_src[k]],
+                    out=buf[right_ghost_slc],
                 )
             if c_hi != 0.0:
                 buf[right_ghost_slc] += c_hi

--- a/tidal/solver/rhs.py
+++ b/tidal/solver/rhs.py
@@ -145,7 +145,10 @@ class RHSEvaluator:
         for term_idx in range(1, len(terms)):
             operated = self._apply_resolved(resolved[term_idx], fields)
             coeff = self._coeff_eval.resolve(
-                terms[term_idx], t, eq_idx=eq_idx, term_idx=term_idx,
+                terms[term_idx],
+                t,
+                eq_idx=eq_idx,
+                term_idx=term_idx,
             )
             np.multiply(coeff, operated, out=temp)
             result += temp

--- a/tidal/solver/sparsity.py
+++ b/tidal/solver/sparsity.py
@@ -123,7 +123,8 @@ def _biharmonic_offsets(ndim: int) -> list[tuple[int, ...]]:
 
 
 def _gradient_or_laplacian_offsets(
-    name: str, ndim: int,
+    name: str,
+    ndim: int,
 ) -> list[tuple[int, ...]] | None:
     """Try to resolve gradient_X or laplacian_X operators."""
     deltas = _fd_deltas()


### PR DESCRIPTION
## Summary

Four issues, landing together because they are coupled: the reformat is only safe to keep if CI enforces it, and #423 was merged into this branch as a stacked PR.

**Closes #399, #328, #418, #338.**

## What's here

### #399 — ruff format drift

`ruff check` and `ruff format` had drifted apart: `E501` is lint-ignored, so the formatter's line-splitting was never enforced and 52 files accumulated formatting the tool would rewrite. CI ran `ruff check` but never `ruff format --check`, which is why this happened without a single PR failing.

- the mechanical reformat, 52 files
- `.git-blame-ignore-revs` pointing at it
- **`ruff format --check` added to `.github/workflows/test.yml`** — the half that prevents recurrence

**Semantically inert, and verified rather than assumed**: every touched file was parsed before and after and the ASTs compared — all 52 identical. Blame-ignore verified behaviourally too: a reformatted line in `tidal/solver/sparsity.py` blames to the reformat without the file and to its original April commit (`70d15f6c`) with it.

### #328 — `hpc_shuttle.sh pull` could not resolve recorded output paths

Larger than it first appeared, and the first commit here only fixed a quarter of it.

`--output` is recorded verbatim in `.hpc_jobs`, so `${RESULTS_DIR}` — defined only inside the sbatch script on the compute node — was stored literally and handed to rsync unexpanded. Fixed at submit time *and* pull time, since a submit-only fix leaves every existing record broken.

But `cmd_pull` extracted with `awk '$2==j' | tail -1`, which returns only a record's **first line**. Commands are recorded with backslash continuations spanning up to 22 lines, so for most jobs the `--output` was never found at all.

Measured over `scripts/.hpc_jobs` (244 job ids):

| | before | after |
|---|---|---|
| jobs with a findable `--output` | 106 | **175** |
| fully resolved to a concrete path | — | **168** |
| pointing at a PNG instead of the run directory | 35 | **0** |
| unresolvable | — | 7 (now fail loudly) |

Three things the obvious fix would have missed:

- **`tail -1` is the wrong pick.** Chained commands (`tidal sample ... && tidal plot ... --output .../corner.png`) record the run directory first and a figure last, and `pull` wants the directory — 35 jobs would have rsync'd a single PNG. Switching to `head -1` alone doesn't fix it either, because a greedy `sed` collapses to the last match *per line*; it needs `grep -o`.
- **`${OUTPUT_DIR}` is recoverable.** It isn't template-defined, but it's assigned inline within the record itself, so 34 more paths resolve.
- **mawk.** The natural record-boundary regex `/^[0-9]{4}-/` **silently matches nothing** here — mawk doesn't support interval expressions. It has to use literal repetition, or the fix looks right and does nothing.

The 7 that remain unresolvable (`${CAMPAIGN_DIR}` on jobs submitted without `--campaign`) now `die` with an actionable message instead of handing rsync a malformed path.

### #418 — `tidal list` from a wheel

Neither lookup in `_find_examples_dir` succeeds when installed from a wheel, so the command reported a missing cwd-relative path — reading as broken rather than as a packaging boundary. Now distinguishes an explicit bad `--dir` from the default case, and the latter points at the repository. (Its old hint also said "positional arg" when the argument is `--dir`.)

### #338 — κ dimension annotations

`manuscript/macros.tex` contradicted itself: the `kappa_TIDAL` block gives κ correctly as [Mass⁻¹], while three nearby comments labelled κ² as [Mass⁻¹] and the squared Planck masses as [Mass]. Corrected to [Mass⁻²] and [Mass²]. Comments only — no macro definition or rendered output changes.

### Near-free corrections (no issue closed)

- **CLI no longer advertises ghost detection.** `--stability` help promised it; `_run_stability_checks` explicitly declines to attempt it, because in linearised GR the naive Hamiltonian kinetic coefficients are negative even for ghost-free theories.
- **Soft-floor rationale repointed #372 → #375.** Three comments cited the Appendix E kinetic-matrix issue instead of the logZ-contamination one. The genuine #372 refs in `latex.py` / `kinetic_matrix.py` are untouched.
- **`build_inverse_kinetic_diag` docstring** described modal reducing an array via `.ravel()[0]` and pointed at "`modal.py:732`". Neither is real — modal never passes `grid=`, so it never receives an array. Now points at #421.
- **Two test assertions.** `test_list_custom_dir` asserted the plural "specifications found"; the inline-spec fixtures share one session directory, so it only held once another fixture had written a second spec there — **it failed on `origin/main` when the class was run alone, before any change here**. And `test_probe_perf`'s docstring claimed a 6 ms budget while asserting 80 ms, with an unfilled `commit XXXXXXX` placeholder. No budget was changed.

## Testing

- `uv run pytest tests/ -q` → **2583 passed, 5 skipped**
- `uv run ruff check` → All checks passed
- `uv run ruff format --check .` → 297 files already formatted
- `uv run pyright` → 0 errors, 0 warnings
- `cspell` → 0 issues
- `bash -n scripts/hpc_shuttle.sh` → clean; extraction exercised against all 244 records in `.hpc_jobs`

## Note

One commit message (`88c6db96`) lost a quoted example to shell backtick expansion — "Chained commands () record…". Content is unaffected; not force-pushed to avoid disrupting a concurrent session on this branch.

## Related Issues

Closes #399, closes #328, closes #418, closes #338. Refs #421, #375.
