### PR TITLE
fix: shuttle ${RESULTS_DIR}, tidal list on wheels, kappa dimensions (#328, #418, #338)

### DIFF
--- a/manuscript/macros.tex
+++ b/manuscript/macros.tex
@@ -118,7 +118,7 @@
 \newcommand*{\SUNDIALS}{\textit{SUNDIALS}\xspace}
 
 % === Planck scale ===
-% Reduced Planck mass: M_P, with M_P^2 = 1/(8 pi G), units [Mass]
+% Reduced Planck mass: M_P, with M_P^2 = 1/(8 pi G), units [Mass^2]
 % Convention: MacrosMAG.tex (2406.12826); BHL joint corpus
 %
 % Relation to TIDAL's kappa (see "Gravitational coupling" block below):
@@ -141,7 +141,7 @@
 %   - Metric perturbation:  g_{mu nu} = eta_{mu nu} + h_{mu nu}
 %     (RAW perturbation, NO kappa factor in the field redefinition)
 %   - Action prefactor:     L = (1/kappa^2) R - (1/4) F^2
-%   - Numerical value:      kappa^2 = 16 pi G,   units [Mass^{-1}]
+%   - Numerical value:      kappa^2 = 16 pi G,   units [Mass^{-2}]
 %   - Planck-mass relation: kappa = sqrt(2)/M_P,  M_P = sqrt(2)/kappa
 %
 % kappa appears in two places:
@@ -292,7 +292,7 @@
 %   Convention: Hehl et al. Rev.Mod.Phys. 48, 393 (1976); Shapiro hep-th/0103093
 %   Macro: \MAGT{^\alpha_\mu_\nu} or \T[]{mu nu rho} for irrep components
 %
-% Gravitational coupling (vertex):  kappa^2 = 16 pi G,  units [Mass^{-1}]
+% Gravitational coupling (vertex):  kappa^2 = 16 pi G,  units [Mass^{-2}]
 %   - Appears in g = eta + kappa h and in P_conv = sin^2(kappa B_0 D / 2)
 %   - NOT the same as the Einstein-action constant kappa_E = 8 pi G
 %   - See the full block-comment in the "Gravitational coupling" section above
@@ -305,7 +305,7 @@
 %   Macro: \Alp{n}, \Bet{n}, \Gam{n}
 %
 % Planck mass:  m_P  (reduced Planck mass)
-%   m_P^2 = 1 / (8 pi G) = 2 / kappa^2,    units [Mass]
+%   m_P^2 = 1 / (8 pi G) = 2 / kappa^2,    units [Mass^2]
 %   m_P = sqrt(2) / kappa
 %   - Action prefactor on Ricci scalar: -(1/2) m_P^2 R  (BHL joint convention)
 %   Convention: MacrosMAG.tex (2406.12826); BHL joint papers

--- a/scripts/hpc_shuttle.sh
+++ b/scripts/hpc_shuttle.sh
@@ -231,6 +231,11 @@ cmd_submit() {
   if [[ -n "$campaign" ]]; then
     recorded_cmd="${cmd//\$\{CAMPAIGN_DIR\}/${camp_path}}"
   fi
+  # ${RESULTS_DIR} is only defined inside the sbatch script on the compute
+  # node, so a literal one recorded here would be unresolvable at pull time.
+  # The job id is known now, so expand it to the same path the template uses.
+  recorded_cmd="${recorded_cmd//\$\{RESULTS_DIR\}/${REMOTE_ROOT}/hpc_results/${jobid}}"
+  recorded_cmd="${recorded_cmd//\$RESULTS_DIR/${REMOTE_ROOT}/hpc_results/${jobid}}"
   echo "$(date -Iseconds) $jobid $name $template $recorded_cmd" >> "$JOBS_FILE"
   echo "$jobid"
   # User-visible reminder: HPC jobs that crash on startup typically die
@@ -307,6 +312,10 @@ cmd_pull() {
       line="$(awk -v j="$jobid" '$2==j' "$JOBS_FILE" | tail -1)"
       if [[ -n "$line" ]]; then
         src="$(sed -n 's/.*--output \([^ ]*\).*/\1/p' <<<"$line")"
+        # Records written before ${RESULTS_DIR} was expanded at submit time
+        # carry the literal string.  Resolve it here so historical jobs pull.
+        src="${src//\$\{RESULTS_DIR\}/${REMOTE_ROOT}/hpc_results/${jobid}}"
+        src="${src//\$RESULTS_DIR/${REMOTE_ROOT}/hpc_results/${jobid}}"
       fi
     fi
     [[ -n "$src" ]] || die "could not resolve remote output path for job $jobid; pass --src PATH explicitly"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -692,11 +693,48 @@ class TestListCommand:
 
         out = capsys.readouterr().out
         assert "klein_gordon_1d.json" in out
-        assert "specifications found" in out
+        # The inline-spec fixtures share one session directory, so the count
+        # depends on which other fixtures have run.  Match either form rather
+        # than depending on test ordering.
+        assert re.search(r"\d+ specifications? found", out)
 
-    def test_list_nonexistent_dir(self) -> None:
+    def test_list_nonexistent_dir(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         ret = main(["list", "--dir", "/nonexistent/dir"])
         assert ret == 1
+
+        err = capsys.readouterr().err
+        assert "/nonexistent/dir" in err
+        assert "--dir" in err
+
+    def test_list_no_examples_dir_hints_at_repository(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Installed-from-a-wheel case: no examples/data anywhere (#418).
+
+        The distribution ships only the ``tidal`` package, so neither the
+        cwd nor the package parent holds ``examples/data``.  The user gets
+        an actionable hint rather than an empty table.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            "tidal.cli._list._find_examples_dir",
+            lambda: tmp_path / "examples" / "data",
+        )
+
+        ret = main(["list"])
+        assert ret == 1
+
+        err = capsys.readouterr().err
+        assert "no examples directory found" in err
+        # Points at the repository rather than just reporting a missing path.
+        assert "repository" in err
+        assert "--dir" in err
 
 
 class TestSimulateCommand:

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -270,7 +270,12 @@ class TestProbePerformance:
         return _load_t1()
 
     def test_probe_perf(self, t1: tuple[EquationSystem, GridInfo]) -> None:
-        """Median probe wall ≤ 6 ms over 1000 random param dicts (T1, N=32)."""
+        """Probe wall stays within the recorded budget (T1, N=32).
+
+        Guard only -- the asserted budget below is the operative number.
+        Wall-clock here is load-sensitive, so this catches gross regressions
+        rather than pinning a precise figure.
+        """
         spec, grid = t1
 
         rng = np.random.default_rng(0)
@@ -311,13 +316,14 @@ class TestProbePerformance:
         #  * Phases 1-2 (commit 350b53b et al.): per-process spec cache
         #    + parameter-independent structural cache for the probe
         #    saved ~2 ms/call.
-        #  * Phase 3 (commit XXXXXXX): ``np.einsum`` → ``np.matmul``
+        #  * Phase 3 (commit 49c9d447): ``np.einsum`` → ``np.matmul``
         #    refactor inside ``_build_evolution_matrices``.  Batched
         #    3-D matmul dispatches to BLAS gemm; the 3-way einsums
         #    that replicated ``(U @ K) @ V`` were ~70× slower without
         #    ``optimize=True``.  Saved ~12 ms/call.
         #
-        # Combined: median dropped from ≈ 27.6 ms → ≈ 13 ms (2.13×).
+        # Combined, as measured at the time: ≈ 27.6 ms → ≈ 13 ms (2.13×).
+        # (Historical -- superseded by the post-#341 figure below.)
         #
         # Post-#341 (threshold 0.30 → 0.15): the spectral-radius
         # prefilter cutoff is ``threshold * t_test`` so dropping the

--- a/tidal/cli/__init__.py
+++ b/tidal/cli/__init__.py
@@ -688,9 +688,10 @@ def _build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
         action="store_true",
         default=False,
         help=(
-            "Run stability checks: tachyon detection (negative mass-matrix eigenvalues) "
-            "and ghost detection (wrong-sign kinetic terms from Hamiltonian). "
-            "Uses a 1-point grid; exact for constant-coefficient systems."
+            "Run stability checks: tachyon detection (negative mass-matrix "
+            "eigenvalues). Uses a 1-point grid; exact for constant-coefficient "
+            "systems. Ghost detection is not included -- Hamiltonian kinetic "
+            "coefficients alone cannot distinguish ghosts from gauge structure."
         ),
     )
     validate_parser.add_argument(
@@ -1994,7 +1995,7 @@ def _build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
             "(default: -100). For baseline-normalized maximize/minimize runs the "
             "natural physics logL is near 0, so -100 drags logZ to -100 and makes "
             "the PolyChord precision criterion unreachable. Use -15 (or similar) "
-            "to keep logZ in a sensible range. See issue #372."
+            "to keep logZ in a sensible range. See issue #375."
         ),
     )
     # Sampling method

--- a/tidal/cli/_list.py
+++ b/tidal/cli/_list.py
@@ -41,15 +41,32 @@ def list_command(args: Namespace) -> int:
     from tidal.cli._inspect import discover_parameters
     from tidal.symbolic.json_loader import load_equation_system
 
-    scan_dir = Path(args.dir) if args.dir else _find_examples_dir()
+    explicit_dir = args.dir is not None
+    scan_dir = Path(args.dir) if explicit_dir else _find_examples_dir()
 
     if not scan_dir.is_dir():
         from tidal.cli._console import error_with_hint
 
-        error_with_hint(
-            f"directory not found: {scan_dir}",
-            hints=["Default: examples/data/. Override with positional arg."],
-        )
+        if explicit_dir:
+            error_with_hint(
+                f"directory not found: {scan_dir}",
+                hints=["Check the path given to --dir."],
+            )
+        else:
+            # Neither the cwd nor the package parent holds examples/data.
+            # The usual cause is an installed wheel: the distribution ships
+            # only the ``tidal`` package, so the example specs are absent
+            # (see [tool.setuptools.packages.find] in pyproject.toml).
+            error_with_hint(
+                "no examples directory found",
+                hints=[
+                    "The example specs ship with the repository, not with the "
+                    "installed package.",
+                    "Clone it and run from the checkout: "
+                    "git clone https://github.com/WilliamRoyce/tidal",
+                    "Or scan your own specs: tidal list --dir PATH",
+                ],
+            )
         return 1
 
     json_files = sorted(scan_dir.glob("*.json"))

--- a/tidal/cli/_validate.py
+++ b/tidal/cli/_validate.py
@@ -509,7 +509,8 @@ def validate_command(args: Namespace) -> int:
     errors.extend(pert_errors)
     warnings.extend(pert_warnings)
 
-    # Check 6: Stability — tachyon and ghost mode detection
+    # Check 6: Stability — tachyon detection (see _run_stability_checks:
+    # ghost detection is deliberately not attempted here)
     if getattr(args, "stability", False):
         from tidal.symbolic.json_loader import EquationSystem
 

--- a/tidal/inference/_likelihood.py
+++ b/tidal/inference/_likelihood.py
@@ -56,7 +56,7 @@ def _soft_floor_logl(
     tests via ``--soft-floor-noise=0``).  The floor defaults to
     ``SOFT_FLOOR_LOGL`` but can be overridden per-run via
     ``--soft-floor-logl`` when the default -100 contaminates logZ for
-    baseline-normalized likelihoods (see issue #372).
+    baseline-normalized likelihoods (see issue #375).
     """
     if sigma_explore <= 0.0:
         return floor
@@ -110,7 +110,7 @@ class LikelihoodConfig:
     to -100 and makes the PolyChord precision criterion unreachable.  Use
     ``--soft-floor-logl -15`` (or similar) to keep logZ in a sensible range
     so that ``precision_criterion × |logZ|`` stays achievable.
-    See issue #372."""
+    See issue #375."""
 
     def __post_init__(self) -> None:
         valid = {"gaussian", "threshold", "maximize", "minimize", "extremize"}

--- a/tidal/solver/_kinetic.py
+++ b/tidal/solver/_kinetic.py
@@ -191,11 +191,13 @@ def velocity_row_scale(
     -------
     float | NDArray[np.float64]
         Multiplicative factor to apply to every velocity-row contribution
-        for ``field_name``. ``1.0`` for the no-op path. Modal solver paths
-        that pre-build complex per-mode matrices may receive an array here
-        and need to either reduce it (e.g. take ``.ravel()[0]`` for the
-        constant-coefficient approximation) or fail loudly — see
-        ``modal.py:732`` for the current per-mode-Padé behavior.
+        for ``field_name``. ``1.0`` for the no-op path.
+
+        An array is only ever returned when ``grid`` is supplied, which
+        builds the ``coord_arrays`` the expression needs (GH #382).  The
+        four time-domain backends do this; the modal builders currently do
+        not, so a position-dependent kinetic reaching them raises rather
+        than being silently reduced — see GH #421.
 
     See Also
     --------


### PR DESCRIPTION
## Summary

Three small fixes that close issues, plus four near-free corrections to text that had gone stale.

**Stacked on #422** — it branches from that PR to avoid a needless conflict in `tests/test_cli.py`, which the reformat touched. Merge #422 first; the diff here is only the six commits above it.

## Changes

### Closes #328 — `hpc_shuttle.sh pull` couldn't resolve `${RESULTS_DIR}`

The `--output` path was recorded verbatim in `.hpc_jobs`, so a job submitted with `--output ${RESULTS_DIR}/name` stored the literal string. `RESULTS_DIR` is defined only inside the sbatch script on the compute node, so at pull time it expanded to nothing and rsync silently targeted a bogus path.

Fixed at **both** ends. The submit side expands it the way `${CAMPAIGN_DIR}` already is. The pull side is the half that matters for existing data — **78 records in `scripts/.hpc_jobs` already carry the literal string**, and a submit-only fix would leave every one of them unpullable. Verified against a real record:

```
before: ${RESULTS_DIR}/d20_bahamonde_amp
after : /rds/user/wr286/hpc-work/tidal/hpc_results/28591809/d20_bahamonde_amp
```

### Closes #418 — `tidal list` from a wheel

Neither lookup in `_find_examples_dir` succeeds when installed from a wheel, so the command reported a missing cwd-relative path — reading as broken rather than as a packaging boundary. Now distinguishes an explicit bad `--dir` from the default case, and the latter explains that specs live in the repository. Takes the issue's own option 2. (Its old hint also said "positional arg" when the argument is `--dir`.)

### Closes #338 — κ dimension annotations

`macros.tex` contradicted itself: the `kappa_TIDAL` block gives κ correctly as [Mass⁻¹], while three nearby comments labelled κ² as [Mass⁻¹] and the squared Planck masses as [Mass]. Corrected to [Mass⁻²] and [Mass²]. Comments only — no macro definition or rendered output changes.

### Near-free corrections (no issue closed)

- **CLI no longer advertises ghost detection.** `--stability` help promised it; `_run_stability_checks` explicitly declines to attempt it, because in linearised GR the naive Hamiltonian kinetic coefficients are negative even for ghost-free theories. Only tachyon errors are returned. Help text and a stale comment corrected.
- **Soft-floor rationale repointed #372 → #375.** Three comments cited the Appendix E kinetic-matrix issue; the correct reference is the logZ-contamination one. The genuine #372 references in `latex.py` / `kinetic_matrix.py` are untouched.
- **`build_inverse_kinetic_diag` docstring.** It described modal reducing an array via `.ravel()[0]` and pointed at "`modal.py:732`". Neither is real — modal never passes `grid=`, so it never receives an array, and the cited line is a comment. Now describes the actual contract and points at #421.
- **Two test assertions.** `test_list_custom_dir` asserted the plural "specifications found"; the inline-spec fixtures share one session directory, so that only held once another fixture had written a second spec there — **running the class alone failed on `origin/main` before any change here**. And `test_probe_perf`'s docstring claimed a 6 ms budget while asserting 80 ms, with an unfilled `commit XXXXXXX` placeholder. No budget was changed.

## Testing

- `uv run pytest tests/ -q` → **2583 passed, 5 skipped** (one more than baseline: the new #418 test)
- `uv run ruff check` → All checks passed
- `uv run ruff format --check .` → 297 files already formatted
- `uv run pyright` → 0 errors, 0 warnings
- `cspell` → 0 issues
- `bash -n scripts/hpc_shuttle.sh` → syntax clean; substitution exercised against a real `.hpc_jobs` record

## Related Issues

Closes #328, closes #418, closes #338. Refs #421, #375.
