### PR TITLE
fix: reproducible soft-floor noise and renders, and finish the shuttle pull fix (#408, #388, #328)

### DIFF
--- a/scripts/hpc_shuttle.sh
+++ b/scripts/hpc_shuttle.sh
@@ -305,17 +305,63 @@ cmd_pull() {
 
   if [[ -z "$src" ]]; then
     # Parse the --output PATH recorded for this jobid in .hpc_jobs.
-    # Records are space-separated: <iso-date> <jobid> <name> <template> <full-cmd>
-    # The full-cmd contains "--output <path>" which we extract.
+    # A record starts with an ISO date and reads
+    #   <iso-date> <jobid> <name> <template> <full-cmd>
+    # but the full-cmd is often written with backslash continuations, so a
+    # record can span many lines and the --output may sit on any of them.
+    # Collect the whole record, not just its first line.
+    #
+    # NOTE: the record-start regex uses literal digit repetition rather than
+    # {4}.  mawk (the default awk here) does not support interval
+    # expressions, so /^[0-9]{4}-/ silently matches nothing.
     if [[ -f "$JOBS_FILE" ]]; then
-      local line
-      line="$(awk -v j="$jobid" '$2==j' "$JOBS_FILE" | tail -1)"
-      if [[ -n "$line" ]]; then
-        src="$(sed -n 's/.*--output \([^ ]*\).*/\1/p' <<<"$line")"
-        # Records written before ${RESULTS_DIR} was expanded at submit time
-        # carry the literal string.  Resolve it here so historical jobs pull.
+      local record
+      record="$(awk -v j="$jobid" '
+        /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T/ {
+          inrec = ($2 == j)
+          if (inrec) rec = ""          # last submission of a resubmitted id wins
+        }
+        inrec { rec = rec $0 "\n" }
+        END { printf "%s", rec }
+      ' "$JOBS_FILE")"
+      if [[ -n "$record" ]]; then
+        # Take the FIRST --output: chained commands (`tidal sample ... &&
+        # tidal plot ... --output .../corner.png`) put the run directory
+        # first and a figure last, and pull wants the directory.  grep -o
+        # rather than sed, because a greedy sed collapses to the last match
+        # on each line.
+        src="$(printf '%s' "$record" \
+          | grep -o -- '--output[[:space:]][[:space:]]*[^[:space:]][^[:space:]]*' \
+          | head -1 \
+          | sed 's/^--output[[:space:]][[:space:]]*//')"
+
+        # Records written before submit-time expansion carry literal shell
+        # variables.  Resolve the ones that are derivable here.
+        #
+        # OUTPUT_DIR is not template-defined -- it is assigned inline in the
+        # recorded command itself -- so recover it from the record.
+        if [[ "$src" == *'${OUTPUT_DIR}'* || "$src" == *'$OUTPUT_DIR'* ]]; then
+          local outdir
+          outdir="$(printf '%s' "$record" \
+            | grep -o 'OUTPUT_DIR=[^ ;]*' | head -1 | cut -d= -f2-)"
+          if [[ -n "$outdir" ]]; then
+            src="${src//\$\{OUTPUT_DIR\}/${outdir}}"
+            src="${src//\$OUTPUT_DIR/${outdir}}"
+          fi
+        fi
         src="${src//\$\{RESULTS_DIR\}/${REMOTE_ROOT}/hpc_results/${jobid}}"
         src="${src//\$RESULTS_DIR/${REMOTE_ROOT}/hpc_results/${jobid}}"
+        src="${src//\$\{TIDAL_ROOT\}/${REMOTE_ROOT}}"
+        src="${src//\$\{REMOTE_ROOT\}/${REMOTE_ROOT}}"
+        src="${src//\$\{SLURM_JOB_ID\}/${jobid}}"
+
+        # Anything still carrying a shell variable cannot be resolved from
+        # the record alone (e.g. ${CAMPAIGN_DIR} on a job submitted without
+        # --campaign); fail loudly rather than rsync a malformed path.
+        if [[ "$src" == *'$'* ]]; then
+          die "recorded --output for job $jobid still contains an unresolved variable: $src
+       pass --src PATH explicitly"
+        fi
       fi
     fi
     [[ -n "$src" ]] || die "could not resolve remote output path for job $jobid; pass --src PATH explicitly"

--- a/tests/test_likelihood_soft_floor_noise.py
+++ b/tests/test_likelihood_soft_floor_noise.py
@@ -16,7 +16,9 @@ import pytest
 
 from tidal.inference._likelihood import (
     SOFT_FLOOR_LOGL,
+    _floor_rng,
     _soft_floor_logl,
+    parse_likelihood,
 )
 
 
@@ -44,12 +46,59 @@ class TestSoftFloorLogL:
         assert 0.85 < std < 1.15, f"sample std {std} not ~1.0"
 
     def test_repeated_calls_with_default_rng_produce_different_values(self) -> None:
-        """Without an explicit RNG, distinct calls give distinct floor values
-        — what gives the sampler a gradient.
+        """With no generator supplied, distinct calls give distinct values.
+
+        This is the bare-helper contract only.  Production no longer relies
+        on it: ``_evaluate_likelihood`` passes a ``theta``-derived generator
+        so the floor is reproducible per parameter point (issue #408).  The
+        gradient the sampler needs comes from the noise varying *across*
+        samples, not from it varying between repeated evaluations of the
+        same one.
         """
         floors = {_soft_floor_logl(1.0) for _ in range(50)}
         # Allow up to one duplicate by chance; >=49/50 unique is the bar
         assert len(floors) >= 48
+
+
+class TestFloorRng:
+    """The theta-derived generator behind reproducible soft-floor noise."""
+
+    def test_same_seed_and_theta_reproduce(self) -> None:
+        theta = [1.0, -2.5, 3.25]
+        a = _soft_floor_logl(1.0, SOFT_FLOOR_LOGL, _floor_rng(42, theta))
+        b = _soft_floor_logl(1.0, SOFT_FLOOR_LOGL, _floor_rng(42, theta))
+        assert a == b
+
+    def test_different_theta_gives_different_noise(self) -> None:
+        a = _soft_floor_logl(1.0, SOFT_FLOOR_LOGL, _floor_rng(42, [1.0, 2.0]))
+        b = _soft_floor_logl(1.0, SOFT_FLOOR_LOGL, _floor_rng(42, [1.0, 2.0001]))
+        assert a != b
+
+    def test_different_seed_gives_different_noise(self) -> None:
+        theta = [1.0, 2.0]
+        a = _soft_floor_logl(1.0, SOFT_FLOOR_LOGL, _floor_rng(42, theta))
+        b = _soft_floor_logl(1.0, SOFT_FLOOR_LOGL, _floor_rng(43, theta))
+        assert a != b
+
+    def test_independent_of_evaluation_order(self) -> None:
+        """The guard against regressing to counter-based seeding.
+
+        A counter restarts at zero in every multiprocessing worker, so the
+        k-th task on each worker would draw identical noise.  Deriving from
+        theta means the value cannot depend on how many evaluations came
+        before it.
+        """
+        theta = [0.5, 0.25]
+        first = _soft_floor_logl(1.0, SOFT_FLOOR_LOGL, _floor_rng(7, theta))
+        for other in ([9.0], [1.0, 1.0], [3.3, 4.4, 5.5]):
+            _soft_floor_logl(1.0, SOFT_FLOOR_LOGL, _floor_rng(7, other))
+        later = _soft_floor_logl(1.0, SOFT_FLOOR_LOGL, _floor_rng(7, theta))
+        assert first == later
+
+    def test_config_carries_the_seed(self) -> None:
+        assert parse_likelihood("P_max:maximize").noise_seed == 0
+        assert parse_likelihood("P_max:maximize", noise_seed=7).noise_seed == 7
+        assert parse_likelihood("P_max:minimize", noise_seed=7).noise_seed == 7
 
     def test_floor_well_below_typical_real_loglikelihood(self) -> None:
         """Real samples (typical logL > -50) should always out-compete the
@@ -80,3 +129,66 @@ class TestSoftFloorLogL:
         assert abs(std - sigma) / sigma < 0.1, (
             f"empirical std {std} doesn't match sigma {sigma}"
         )
+
+
+class TestEvaluateLikelihoodDeterminism:
+    """End-to-end: the floor is reproducible through ``_evaluate_likelihood``.
+
+    The helper-level tests above would still pass if a call site were wired
+    up wrongly (say, passing the wrong variable into ``_floor_rng``), so
+    this drives the real function.  A nonexistent spec path sends it down
+    the ``run_status="exception"`` branch, which is one of the four floor
+    returns.  See issue #408.
+    """
+
+    @staticmethod
+    def _evaluate(theta: list[float], *, noise_seed: int = 42) -> tuple[float, str]:
+        from argparse import Namespace
+        from pathlib import Path
+
+        from tidal.inference._likelihood import (
+            LikelihoodConfig,
+            _evaluate_likelihood,
+        )
+
+        config = LikelihoodConfig(
+            metric="P_max",
+            likelihood_type="maximize",
+            soft_floor_noise_sigma=1.0,
+            noise_seed=noise_seed,
+        )
+        logl, meta = _evaluate_likelihood(
+            theta=theta,
+            base_args=Namespace(),
+            spec_path=Path("/nonexistent/spec.json"),
+            param_names=["a", "b"],
+            measurements={"peak_conversion"},
+            source=None,
+            target=None,
+            threshold=0.0,
+            likelihood_config=config,
+            temp_dir=None,
+            keep_sims=False,
+            call_index=0,
+        )
+        return logl, str(meta["run_status"])
+
+    def test_same_theta_gives_identical_logl(self) -> None:
+        first, status = self._evaluate([1.0, 2.0])
+        second, _ = self._evaluate([1.0, 2.0])
+        assert status == "exception"
+        assert first == second
+
+    def test_different_theta_gives_different_logl(self) -> None:
+        first, _ = self._evaluate([1.0, 2.0])
+        other, _ = self._evaluate([1.0, 2.5])
+        assert first != other
+
+    def test_different_noise_seed_gives_different_logl(self) -> None:
+        first, _ = self._evaluate([1.0, 2.0], noise_seed=42)
+        other, _ = self._evaluate([1.0, 2.0], noise_seed=43)
+        assert first != other
+
+    def test_floor_value_is_near_the_configured_floor(self) -> None:
+        logl, _ = self._evaluate([1.0, 2.0])
+        assert abs(logl - SOFT_FLOOR_LOGL) < 10.0

--- a/tests/test_render_determinism.py
+++ b/tests/test_render_determinism.py
@@ -1,0 +1,64 @@
+"""Determinism of anesthetic-backed rendering and bootstrap statistics.
+
+anesthetic draws from NumPy's *legacy* global RNG in two places that
+matter here: ``compress_weights`` / ``triangular_sample_compression_2d``
+during KDE plotting, and ``logX`` inside ``NestedSamples.stats``.  Neither
+accepts a ``Generator``, so the only lever is the global state.
+
+``_deterministic_render`` seeds it and — the part that matters — restores
+it afterwards, so a render cannot leave the process in a fixed state for
+whatever runs next.  See issue #388.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tidal.inference._visualize import _deterministic_render
+
+
+class TestDeterministicRender:
+    def test_restores_global_state(self) -> None:
+        """The context manager must not leak a seeded state to its caller."""
+        np.random.seed(12345)  # noqa: NPY002
+        before = np.random.get_state()  # noqa: NPY002
+
+        with _deterministic_render():
+            np.random.rand(100)  # noqa: NPY002  # consume, as anesthetic does
+
+        after = np.random.get_state()  # noqa: NPY002
+        assert before[0] == after[0]
+        assert np.array_equal(before[1], after[1])
+        assert before[2] == after[2]
+
+    def test_inner_draws_reproduce_across_entries(self) -> None:
+        with _deterministic_render():
+            first = np.random.rand(4)  # noqa: NPY002
+
+        np.random.rand(999)  # noqa: NPY002  # perturb the outer stream
+
+        with _deterministic_render():
+            second = np.random.rand(4)  # noqa: NPY002
+
+        assert np.array_equal(first, second)
+
+    def test_outer_stream_unaffected_by_inner_consumption(self) -> None:
+        """How much the block consumes must not shift the caller's stream."""
+        np.random.seed(7)  # noqa: NPY002
+        expected = np.random.rand()  # noqa: NPY002
+
+        np.random.seed(7)  # noqa: NPY002
+        with _deterministic_render():
+            np.random.rand(50)  # noqa: NPY002
+        actual = np.random.rand()  # noqa: NPY002
+
+        assert expected == actual
+
+    def test_distinct_seeds_give_distinct_draws(self) -> None:
+        """Negative control: a degenerate implementation would pass the rest."""
+        with _deterministic_render(seed=0):
+            a = np.random.rand(4)  # noqa: NPY002
+        with _deterministic_render(seed=1):
+            b = np.random.rand(4)  # noqa: NPY002
+
+        assert not np.array_equal(a, b)

--- a/tidal/cli/_sample.py
+++ b/tidal/cli/_sample.py
@@ -151,6 +151,9 @@ def sample_command(args: Namespace) -> int:  # noqa: C901, PLR0911, PLR0912, PLR
     from tidal.inference._likelihood import SOFT_FLOOR_LOGL
 
     soft_floor_logl: float = float(getattr(args, "soft_floor_logl", SOFT_FLOOR_LOGL))
+    # Read --seed here rather than at the "Common settings" block below: the
+    # likelihood needs it so soft-floor noise is reproducible (issue #408).
+    seed: int = getattr(args, "seed", 42)
     try:
         likelihood_config = parse_likelihood(
             likelihood_spec,
@@ -158,6 +161,7 @@ def sample_command(args: Namespace) -> int:  # noqa: C901, PLR0911, PLR0912, PLR
             permissive=(not gated),
             soft_floor_noise_sigma=soft_floor_noise,
             soft_floor_logl=soft_floor_logl,
+            noise_seed=seed,
         )
     except ValueError as e:
         error_with_hint(str(e), ["Check --likelihood format: METRIC:TYPE[:ARGS]"])
@@ -208,7 +212,6 @@ def sample_command(args: Namespace) -> int:  # noqa: C901, PLR0911, PLR0912, PLR
     # --- Common settings ---
     method: str = getattr(args, "method", "mc")
     n_workers: int | None = getattr(args, "parallel", None)
-    seed: int = getattr(args, "seed", 42)
     quiet: bool = getattr(args, "quiet", False)
 
     param_names = prior_param_names(priors)

--- a/tidal/inference/_atlas.py
+++ b/tidal/inference/_atlas.py
@@ -768,15 +768,13 @@ def plot_atlas(
     else:
         rows, cols = _grid_shape(n_dims, layout_cols)
 
-    # Seed numpy's legacy RNG so KDE sample-compression in anesthetic
-    # (anesthetic.utils.triangular_sample_compression_2d uses bare
-    # `np.random.choice` without a Generator) is deterministic across
-    # renders.  Without this, repeated atlas renders of the same survey
-    # produce pixel-different output, which is bad for review diffs.
-    # The legacy global API is required here because anesthetic does not
-    # accept an RNG / Generator handle to thread through; NPY002 cannot
-    # be addressed at this layer.
-    np.random.seed(0)  # noqa: NPY002
+    # KDE sample-compression in anesthetic draws from NumPy's legacy
+    # global RNG, so renders are non-deterministic without a seed.  The
+    # per-panel renders funnel through _render_anesthetic_corner_into,
+    # which seeds and *restores* the global state around each plot_2d
+    # (see _deterministic_render).  A bare np.random.seed() here used to
+    # leave the process in a fixed state for whatever ran next; that is
+    # no longer needed and was itself a leak.  See issue #388.
 
     # Layout figure.
     panel_in = 1.6  # inches per face panel; gives ~5x6 inch atlas for N=6

--- a/tidal/inference/_importance.py
+++ b/tidal/inference/_importance.py
@@ -166,7 +166,14 @@ def compute_parameter_importance(
     ns = to_anesthetic_samples(result)
 
     # --- Total statistics with bootstrap ---
-    stats = ns.stats(nsamples=n_bootstrap)
+    # anesthetic's bootstrap draws from NumPy's legacy global RNG
+    # (anesthetic.samples.logX uses a bare np.random.rand), so logZ and
+    # D_KL error bars vary run to run on identical input.  Seed and
+    # restore around it so repeated calls agree.  See issue #388.
+    from tidal.inference._visualize import _deterministic_render
+
+    with _deterministic_render():
+        stats = ns.stats(nsamples=n_bootstrap)
 
     d_kl_samples = stats["D_KL"].to_numpy()
     d_g_samples = stats["d_G"].to_numpy()

--- a/tidal/inference/_likelihood.py
+++ b/tidal/inference/_likelihood.py
@@ -31,6 +31,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from argparse import Namespace
+    from collections.abc import Sequence
 
 
 # Soft penalty floor for numerical-failure samples (sim divergence, NaN
@@ -63,6 +64,30 @@ def _soft_floor_logl(
     if rng is None:
         rng = np.random.default_rng()
     return floor + float(rng.normal(0.0, sigma_explore))
+
+
+def _floor_rng(noise_seed: int, theta: Sequence[float]) -> np.random.Generator:
+    """Derive the soft-floor generator from the seed and the sample itself.
+
+    Seeding on ``theta`` makes the floor a deterministic function of the
+    parameter point, independent of which worker evaluated it or in what
+    order.  A call counter cannot do this: ``_likelihood_worker_init``
+    gives every ``multiprocessing`` fork a counter starting at zero, so
+    the k-th task on each worker would draw the same noise, and
+    ``pool.imap`` dispatch order is not reproducible in the first place.
+    Storing a ``Generator`` on ``LikelihoodConfig`` fails the same way ---
+    the config is pickled into every fork, so all workers would resume
+    from one state.
+
+    See issue #408.
+    """
+    theta_words = np.frombuffer(
+        np.asarray(theta, dtype=np.float64).tobytes(),
+        dtype=np.uint32,
+    )
+    return np.random.default_rng(
+        np.random.SeedSequence([int(noise_seed), *(int(w) for w in theta_words)])
+    )
 
 
 @dataclass(frozen=True)
@@ -112,6 +137,21 @@ class LikelihoodConfig:
     so that ``precision_criterion × |logZ|`` stays achievable.
     See issue #375."""
 
+    noise_seed: int = 0
+    """Seed for the soft-floor exploration noise (default: 0).
+
+    Combined with the sample's own ``theta`` to derive a generator, so a
+    given parameter point always receives the same floor value.  This is
+    a correctness property as much as a reproducibility one: nested
+    sampling assumes the likelihood is a deterministic function of the
+    parameters, and an unseeded floor lets a sample's logL change between
+    live-point insertion and later re-evaluation.
+
+    Seeding on ``theta`` rather than a call counter is deliberate --- a
+    counter restarts at zero in every ``multiprocessing`` worker, so the
+    k-th task on every worker would draw identical noise, and ``imap``
+    dispatch order is not reproducible anyway.  See issue #408."""
+
     def __post_init__(self) -> None:
         valid = {"gaussian", "threshold", "maximize", "minimize", "extremize"}
         if self.likelihood_type not in valid:
@@ -135,6 +175,7 @@ def parse_likelihood(
     permissive: bool = True,
     soft_floor_noise_sigma: float = 1.0,
     soft_floor_logl: float = SOFT_FLOOR_LOGL,
+    noise_seed: int = 0,
 ) -> LikelihoodConfig:
     """Parse a CLI likelihood specification string.
 
@@ -182,6 +223,7 @@ def parse_likelihood(
         "permissive": permissive,
         "soft_floor_noise_sigma": soft_floor_noise_sigma,
         "soft_floor_logl": soft_floor_logl,
+        "noise_seed": noise_seed,
     }
 
     if ltype == "gaussian":
@@ -627,6 +669,7 @@ def _evaluate_likelihood(
                 return _soft_floor_logl(
                     likelihood_config.soft_floor_noise_sigma,
                     likelihood_config.soft_floor_logl,
+                    _floor_rng(likelihood_config.noise_seed, theta),
                 ), {
                     "run_status": "simulation_failed",
                     "exit_code": int(exit_code),
@@ -665,6 +708,7 @@ def _evaluate_likelihood(
             return _soft_floor_logl(
                 likelihood_config.soft_floor_noise_sigma,
                 likelihood_config.soft_floor_logl,
+                _floor_rng(likelihood_config.noise_seed, theta),
             ), {
                 "run_status": "metric_nan",
                 likelihood_config.metric: metric_value_f,
@@ -721,6 +765,7 @@ def _evaluate_likelihood(
             return _soft_floor_logl(
                 likelihood_config.soft_floor_noise_sigma,
                 likelihood_config.soft_floor_logl,
+                _floor_rng(likelihood_config.noise_seed, theta),
             ), {
                 **success_meta,
                 "run_status": "logl_minus_inf",
@@ -747,7 +792,9 @@ def _evaluate_likelihood(
         # still reject these in practice (exp(-100) ~ 4e-44) but sees a
         # gradient in the failure region.
         return _soft_floor_logl(
-            likelihood_config.soft_floor_noise_sigma, likelihood_config.soft_floor_logl
+            likelihood_config.soft_floor_noise_sigma,
+            likelihood_config.soft_floor_logl,
+            _floor_rng(likelihood_config.noise_seed, theta),
         ), {"run_status": "exception"}
 
     finally:

--- a/tidal/inference/_visualize.py
+++ b/tidal/inference/_visualize.py
@@ -17,12 +17,44 @@ import math
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     import numpy as np
 
     from tidal.inference._importance import ParameterImportanceResult
     from tidal.inference._results import InferenceResult
+
+
+# Seed for anesthetic's KDE sample-compression.  See _deterministic_render.
+RENDER_RNG_SEED = 0
+
+
+@contextlib.contextmanager
+def _deterministic_render(seed: int = RENDER_RNG_SEED) -> Iterator[None]:
+    """Make anesthetic's KDE sample-compression reproducible, and local.
+
+    ``anesthetic.utils.compress_weights`` defaults its ``u`` argument to
+    ``np.random.rand(len(w))`` and ``triangular_sample_compression_2d``
+    calls a bare ``np.random.choice``, both of which draw from NumPy's
+    legacy *global* state.  anesthetic exposes no way to thread a
+    ``Generator`` down from its plotting entry points, so seeding that
+    global state is the only lever available at this layer --- hence the
+    ``NPY002`` suppressions below.
+
+    Restoring the previous state on exit is the part that matters.  A bare
+    ``np.random.seed(0)`` leaves the whole process in a known state, so
+    anything drawing from the legacy global afterwards silently becomes a
+    function of how many renders happened first.  See issue #388.
+    """
+    import numpy as np
+
+    state = np.random.get_state()  # noqa: NPY002
+    np.random.seed(seed)  # noqa: NPY002
+    try:
+        yield
+    finally:
+        np.random.set_state(state)  # noqa: NPY002
 
 
 def plot_corner(
@@ -753,6 +785,13 @@ def _render_anesthetic_corner_into(
             atlas T5.1/T5.2 corner panels where one chain hit a sharp peak)
         All fall back to KDE diagonals + scatter cross-panels.
         """
+        # Reseed per attempt: a failed plot_2d has already consumed RNG
+        # state, so without this the fallback would render differently
+        # depending on which attempt succeeded (#388).
+        with _deterministic_render():
+            return _plot_2d_attempts(axes_arg)
+
+    def _plot_2d_attempts(axes_arg: object) -> object:
         try:
             return samples.plot_2d(
                 axes_arg,


### PR DESCRIPTION
## Summary

Two reproducibility fixes — soft-floor likelihood noise and anesthetic-backed rendering — plus the completion of #328, which #422 merged one commit too early to include.

**Closes #408, closes #388, closes #328.**

## ⚠️ Carries the #328 completion

#422 was merged at `8bb76caf`, one commit before the fix completion landed on that branch, so `main` currently has only a quarter of #328 working while the issue read as closed. I have reopened #328; this PR carries commit `88c6db96` which finishes it.

`main` today still extracts with `awk '$2==j' | tail -1`, which returns only a record's first line — and commands are recorded with backslash continuations spanning up to 22 lines, so for most jobs the `--output` is never found at all. Over the 244 job ids in `scripts/.hpc_jobs`:

| | `main` today | with this PR |
|---|---|---|
| jobs with a findable `--output` | 106 | **175** |
| fully resolved to a concrete path | ~19 of 73 affected | **168** |
| pointing at a PNG instead of the run directory | 35 | **0** |
| unresolvable | silent bad path | 7, now fail loudly |

Three details that are easy to get wrong: `tail -1` picks a figure over the run directory for chained commands (and `head -1` alone doesn't fix it, since a greedy `sed` collapses to the last match per line — it needs `grep -o`); `${OUTPUT_DIR}` is recoverable from the record itself; and the natural `/^[0-9]{4}-/` record-boundary regex **silently matches nothing** under mawk, which doesn't support interval expressions.

## #408 — soft-floor noise was unseeded

`_soft_floor_logl` built a fresh unseeded `default_rng()` on every call and no production site passed one, so a sample landing on the soft floor got a different logL each run. `tidal sample` already takes `--seed`, but its reach stopped at prior sampling — it never touched the likelihood, and `run_nested_sampling` has no seed parameter at all.

**This is a correctness fix as much as a reproducibility one.** Nested sampling assumes the likelihood is a deterministic function of the parameters; an unseeded floor lets a sample's logL change between live-point insertion and later re-evaluation.

The generator is derived from `(noise_seed, theta)` via `SeedSequence`, following the idiom already in `tidal/cli/_sweep.py`. **Two natural-looking alternatives were rejected because both are correlation bugs:**

- **A call counter.** `_likelihood_worker_init` gives every `multiprocessing` fork a counter starting at zero, so the k-th task on *every* worker would draw identical noise — and `pool.imap` dispatch order isn't reproducible anyway.
- **A `Generator` stored on `LikelihoodConfig`.** The frozen config is pickled into every fork, so all workers would resume from one state.

Hashing `theta` is worker-agnostic, rank-agnostic and order-agnostic.

Also removes a duplicate read of `args.seed` — it is now read once, above `parse_likelihood`, which needs it.

## #388 — renders drew from the global RNG

anesthetic draws from NumPy's *legacy global* RNG where no `Generator` parameter exists: `compress_weights` defaults `u` to `np.random.rand`, `triangular_sample_compression_2d` calls `np.random.choice`, and `NestedSamples.stats` reaches `np.random.rand` via `logX`.

The atlas path already seeded it — but with a bare `np.random.seed(0)` and **no restore**, so a render left the whole process in a fixed state and anything drawing from the legacy global afterwards silently became a function of how many renders ran first. The corner path didn't seed at all.

`_deterministic_render` seeds *and restores*, applied at `_render_anesthetic_corner_into` — the choke point both paths funnel through. It reseeds per attempt inside the degenerate-posterior fallback chain, since a failed `plot_2d` has already consumed RNG state.

### The issue's premise was wrong in one respect

#388 assumed only pixels were affected. They aren't: `ns.stats(nsamples=...)` reaches the same legacy RNG, so **`logZ` and `D_KL` error bars varied run to run on identical input**. On one unchanged chain, two consecutive calls gave:

```
logZ = -0.0816985977   and   -0.0805400478
```

They are now bit-identical. Per-coupling marginal D_KL is the campaign's headline metric, so this is a scientific-output fix rather than a cosmetic one.

## Testing

- `uv run pytest tests/ -q` → **2596 passed, 5 skipped** (up from 2583; 13 new tests)
- `uv run ruff check` / `ruff format --check` / `pyright` → all clean

**#408** is tested at the helper layer (same seed+theta reproduces; different theta or seed differs; order-independence, which is the guard against regressing to counter-seeding) **and** through the real `_evaluate_likelihood`, since helper tests alone wouldn't catch a mis-wired call site.

**#388** asserts the three properties that matter — global state restored, inner draws reproduce across entries, and the caller's stream is unaffected by how much the block consumed — plus a negative control, since a degenerate implementation would pass the rest.

One existing test (`test_repeated_calls_with_default_rng_produce_different_values`) pinned the old unseeded behaviour. It is kept but re-documented: it covers the bare helper's contract, which production no longer depends on. The sampler's gradient comes from noise varying *across* samples, not across repeated evaluations of one sample.

## Upstream follow-up

The real fix for #388 belongs in anesthetic, and the ask is narrow: `compress_weights` already accepts `u`, so the plotting entry points and `stats` just need to thread an optional `random_state` down to it. A draft is ready to file on `handley-lab/anesthetic`.

## Related Issues

Closes #408, closes #388.
