### PR TITLE
fix(solver): refuse position-dependent kinetics in modal, route selection to time-domain (#421)

### DIFF
--- a/.claude/rules/solver.md
+++ b/.claude/rules/solver.md
@@ -7,7 +7,7 @@ paths:
 # Solver Architecture Rules
 
 ## Solver Selection (auto, by priority)
-1. **Modal** — flat metric + periodic BCs + time-independent + 15 supported operators → Padé matrix-exp (path D, `scipy.linalg.expm`). Eigendecomposition retired v0.31+.
+1. **Modal** — flat metric + periodic BCs + time-independent + constant kinetic coefficients (position-dependent kinetics refused, GH #421/#427) + 15 supported operators → Padé matrix-exp (path D, `scipy.linalg.expm`). Eigendecomposition retired v0.31+. Perturbative eligibility is judged on the canonicalized base spec.
 2. **IDA** — constraints present (time_order=0 fields) → implicit SUNDIALS DAE
 3. **IDA** — first-order equations (time_order=1, diffusion) → implicit BDF
 4. **IDA** — dissipation (`first_derivative_t` in RHS) → implicit BDF

--- a/docs/tex/troubleshooting.tex
+++ b/docs/tex/troubleshooting.tex
@@ -384,6 +384,47 @@ torsion kinetic term; the torsion fields become algebraic constraints and the sy
 reduces to the standard Einstein-Maxwell Gertsenshtein model.  This is a useful
 control check: the conversion probability should recover $P = \sin^2(\kappa B_0 D/2)$.
 
+\subsubsection{NotImplementedError: position-dependent kinetic coefficient in modal}
+\label{sec:troubleshooting-posdep-kinetic-modal}
+
+\textbf{Symptom:}
+\begin{lstlisting}[style=python]
+NotImplementedError: solve_modal cannot handle a position-dependent kinetic
+coefficient (field(s) ['a_1', 'a_2', 'a_3']). A position-dependent M(x) is a
+k-space convolution ...
+\end{lstlisting}
+from \texttt{solve\_modal}, \texttt{solve\_modal\_pass1},
+\texttt{\_build\_evolution\_matrices}, or the conversion-stability probe.
+
+\textbf{Root cause:} The equation's LHS carries a
+\texttt{kinetic\_coefficient\_symbolic} containing spatial coordinates
+(\texttt{x[]}, \texttt{y[]}, \dots), e.g.\ a localized background folded into the
+kinetic term.  In Fourier space a position-dependent mass matrix is a mode-coupling
+convolution $\hat{M}(k - k')$, which the modal solver does not implement (GH \#427
+tracks the feature; the guards are GH \#421).  Before the guards this failed as a
+grid-less \texttt{evaluate\_coefficient} \texttt{ValueError} on some paths and was
+\emph{silently treated as $M = 1$} on the generalized-eigenvalue path --- including
+inside the inference stability probe.
+
+\textbf{Fix (one of):}
+\begin{itemize}
+  \item Use a time-domain solver: \texttt{--scheme cvode} or \texttt{--scheme ida}.
+    Both evaluate position-dependent kinetics per grid point (GH \#382).
+    Auto-selection already routes such specs away from modal.
+  \item If the position-dependence is proportional to a small parameter, declare it
+    in \texttt{[perturbation].small\_parameters}: kinetic canonicalization
+    (GH \#380) moves it into $O(\varepsilon)$ RHS corrections and the base spec
+    stays constant-coefficient (this is the Euler--Heisenberg dual-Gaussian flow).
+  \item If the spec has a \texttt{[perturbation]} block but you passed
+    \texttt{--perturbative-order 0}, the full un-canonicalized spec is solved on
+    the plain modal path --- drop the override or switch scheme.
+\end{itemize}
+
+\textbf{Diagnostic:} \texttt{spec.has\_position\_dependent\_kinetic()} (or check
+per equation via \texttt{ComponentEquation.kinetic\_position\_dependent}).  The
+only shipped spec with position-dependent kinetics is
+\texttt{examples/data/euler\_heisenberg\_e\_dual\_gaussian.json}.
+
 
 \subsection{Debugging Techniques}
 \label{sec:debugging-techniques}

--- a/tests/test_perturbative_driver.py
+++ b/tests/test_perturbative_driver.py
@@ -1191,3 +1191,37 @@ class TestGH380PerturbativeRejectsPosDepBase:
         assert "modal" in msg.lower()
         assert "cvode" in msg.lower() or "ida" in msg.lower()
         assert "position" in msg.lower()
+
+
+class TestGH421BaseKineticGuard:
+    """GH #421 blind-spot fix: `_base_has_position_dependence` previously
+    inspected only RHS terms, so an O(ε⁰) position-dependent kinetic —
+    one NOT proportional to any small parameter, which canonicalization
+    therefore cannot remove — slipped the construction-time guard and
+    failed deep inside the modal builders instead.
+    """
+
+    def test_o_eps0_posdep_kinetic_refused_at_construction(self) -> None:
+        spec_data = copy.deepcopy(_KG_WITH_EPS)
+        # Power-form position dependence (mentions no small parameter, so
+        # it survives canonicalization into the base spec).  Call-form
+        # expressions like Sin[x[]] crash lhs_collapses_to_zero earlier
+        # with an unrelated KineticEvalError — a pre-existing gap tracked
+        # separately from #421.
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = (  # type: ignore[index]
+            "1 + x[]^2"
+        )
+        spec = _make_spec(spec_data)
+        with pytest.raises(NotImplementedError, match="kinetic"):
+            PerturbativeSolver(spec)
+
+    def test_o_eps_posdep_kinetic_still_canonicalized(self) -> None:
+        """A kinetic whose position-dependence is O(ε) is handled by
+        canonicalization (GH #380) and must NOT trip the guard.
+        """
+        spec_data = copy.deepcopy(_KG_WITH_EPS)
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = (  # type: ignore[index]
+            "1 + eps*Sin[x[]]"
+        )
+        solver = PerturbativeSolver(_make_spec(spec_data))
+        assert not solver.base_spec.has_position_dependent_kinetic()

--- a/tests/test_solver_modal.py
+++ b/tests/test_solver_modal.py
@@ -1930,3 +1930,250 @@ class TestOverridePosDepPeriodicScheme:
         new_scheme, msg = _override_pos_dep_periodic_scheme("modal", "auto", spec)
         assert new_scheme == "modal"
         assert msg is None
+
+
+# ---------------------------------------------------------------------------
+# GH #421: position-dependent kinetic coefficients are refused clearly
+# ---------------------------------------------------------------------------
+
+
+class TestGH421PositionDependentKinetic:
+    """The modal solver cannot handle a position-dependent
+    ``kinetic_coefficient_symbolic`` (a mass-side k-space convolution
+    M̂(k−k′), tracked as GH #427).  Pre-guard behavior was a deep
+    grid-less ``evaluate_coefficient`` ValueError on the per-mode and
+    convolution paths, and — worse — a silent ``except Exception → M=1``
+    fallback on the generalized-eig path, which the stability probe (and
+    therefore every inference likelihood evaluation) reaches directly.
+    These tests pin the refusal at every entry and that selection routes
+    around modal.
+    """
+
+    EH_SPEC = "examples/data/euler_heisenberg_e_dual_gaussian.json"
+    EH_PARAMS: dict[str, float] = {
+        "Bpeak": 0.01,
+        "rho": 1.0,
+        "sigma": 1.0,
+        "sigB": 0.4,
+        "zc1": -1.5,
+        "zc2": 1.5,
+    }
+
+    def _load_eh(self, *, strip_perturbation: bool) -> EquationSystem:
+        """Load the only shipped spec with position-dependent kinetics.
+
+        With the ``[perturbation]`` metadata stripped, the CLI's
+        perturbative route (whose canonicalization normalizes the
+        kinetics to '1', GH #380) is disabled and the position
+        dependence reaches the plain modal path unmasked.
+        """
+        import json
+        from pathlib import Path
+
+        raw = json.loads(Path(self.EH_SPEC).read_text(encoding="utf-8"))
+        if strip_perturbation:
+            raw.get("metadata", {}).pop("perturbation", None)
+        return EquationSystem.from_dict(raw)
+
+    @staticmethod
+    def _grid() -> GridInfo:
+        return GridInfo(bounds=((-2.0, 2.0),), shape=(32,), periodic=(True,))
+
+    # -- predicate ------------------------------------------------------
+
+    def test_predicate_on_eh_spec(self) -> None:
+        spec = self._load_eh(strip_perturbation=False)
+        assert spec.has_position_dependent_kinetic()
+        posdep = [
+            eq.field_name for eq in spec.equations if eq.kinetic_position_dependent
+        ]
+        assert posdep == ["a_1", "a_2", "a_3"]
+
+    def test_predicate_constant_and_time_only_kinetics(self) -> None:
+        """Parameter-only and t[]-only kinetics are NOT position-dependent."""
+        spec_data = copy.deepcopy(_KG_1D_SPEC)
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = (  # type: ignore[index]
+            "-kappa^(-2)"
+        )
+        assert not _make_spec(spec_data).has_position_dependent_kinetic()
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = "1 + t[]"  # type: ignore[index]
+        assert not _make_spec(spec_data).has_position_dependent_kinetic()
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = (  # type: ignore[index]
+            "1 + Sin[x[]]"
+        )
+        assert _make_spec(spec_data).has_position_dependent_kinetic()
+
+    def test_predicate_ignores_constraint_equations(self) -> None:
+        """Only dynamical equations count — consumer-faithful to
+        build_inverse_kinetic_diag, which skips time_order=0 rows.
+        """
+        spec_data = copy.deepcopy(_KG_1D_SPEC)
+        spec_data["equations"][0]["lhs"]["order"]["time"] = 0  # type: ignore[index]
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = (  # type: ignore[index]
+            "1 + Sin[x[]]"
+        )
+        assert not _make_spec(spec_data).has_position_dependent_kinetic()
+
+    # -- eligibility ----------------------------------------------------
+
+    def test_can_use_modal_rejects_posdep_kinetic(self) -> None:
+        spec = self._load_eh(strip_perturbation=True)
+        assert can_use_modal(spec, self._grid(), None) is False
+
+    def test_can_use_modal_accepts_constant_symbolic_kinetic(self) -> None:
+        spec_data = copy.deepcopy(_KG_1D_SPEC)
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = (  # type: ignore[index]
+            "-kappa^(-2)"
+        )
+        grid = GridInfo(shape=(64,), bounds=((0.0, 10.0),), periodic=(True,))
+        assert can_use_modal(_make_spec(spec_data), grid, None) is True
+
+    def test_can_use_modal_accepts_canonicalized_base(self) -> None:
+        """The EH campaign flow stays modal-eligible: the driver-style
+        canonicalized base spec has constant kinetics (GH #380), so the
+        new check must not fire on it.  This is the regression pin for
+        auto-selection of the perturbative flow.
+        """
+        spec = self._load_eh(strip_perturbation=False)
+        small = list(spec.metadata.get("perturbation", {}).get("small_parameters", []))
+        base = spec.canonicalize_kinetic_for_perturbation(small).base_spec(small)
+        assert not base.has_position_dependent_kinetic()
+        assert can_use_modal(base, self._grid(), None) is True
+
+    # -- entry guards ---------------------------------------------------
+
+    def test_solve_modal_raises_actionable(self) -> None:
+        spec = self._load_eh(strip_perturbation=True)
+        layout = StateLayout.from_spec(spec, self._grid().num_points)
+        y0 = np.zeros(layout.num_slots * self._grid().num_points)
+        with pytest.raises(NotImplementedError, match="kinetic") as exc_info:
+            solve_modal(
+                spec,
+                self._grid(),
+                y0,
+                (0.0, 1.0),
+                parameters=self.EH_PARAMS,
+            )
+        # The message must name a way out, not just the failure.
+        assert "--scheme cvode" in str(exc_info.value)
+        assert "small_parameters" in str(exc_info.value)
+
+    def test_build_evolution_matrices_raises_not_silent_m1(self) -> None:
+        """The genEig builder previously swallowed the evaluation failure
+        (``except Exception → M_mat = 1``) — wrong physics, no error.
+        """
+        from tidal.solver.coefficients import CoefficientEvaluator
+        from tidal.solver.modal import (
+            _build_evolution_matrices,
+            _build_k_axes,
+            _build_k_grid,
+        )
+
+        spec = self._load_eh(strip_perturbation=True)
+        grid = self._grid()
+        layout = StateLayout.from_spec(spec, grid.num_points)
+        ce = CoefficientEvaluator(spec, grid, self.EH_PARAMS)
+        k_grid = _build_k_grid(_build_k_axes(grid))
+        rfft_shape = (grid.shape[0] // 2 + 1,)
+        with pytest.raises(NotImplementedError, match="kinetic"):
+            _build_evolution_matrices(spec, layout, grid, ce, k_grid, rfft_shape)
+
+    def test_stability_probe_propagates_guard(self) -> None:
+        """check_conversion_stability reaches _build_evolution_matrices
+        directly (it gates every likelihood evaluation in inference); its
+        (LinAlgError, ValueError) handler must NOT swallow the guard into
+        a fabricated 'tachyonic' verdict.
+        """
+        from tidal.measurement._stability import check_conversion_stability
+
+        spec = self._load_eh(strip_perturbation=True)
+        with pytest.raises(NotImplementedError, match="kinetic"):
+            check_conversion_stability(
+                spec,
+                self._grid(),
+                self.EH_PARAMS,
+                source="a_1",
+            )
+
+    def test_stability_probe_constant_kinetic_still_works(self) -> None:
+        """A constant symbolic kinetic must still pass through the probe."""
+        from tidal.measurement._stability import check_conversion_stability
+
+        spec_data = copy.deepcopy(_KG_1D_SPEC)
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = "2"  # type: ignore[index]
+        spec = _make_spec(spec_data)
+        grid = GridInfo(shape=(32,), bounds=((0.0, 10.0),), periodic=(True,))
+        result = check_conversion_stability(spec, grid, {"m2": 1.0}, source="phi_0")
+        assert result.stable is not None  # produced a verdict, no raise
+
+    def test_solve_modal_pass1_raises_on_posdep_correction(self) -> None:
+        """The Pass 1 source builder consumes correction-spec kinetics
+        without a grid; the guard must fire before eigendata is touched.
+        """
+        from tidal.solver.modal import solve_modal_pass1
+
+        spec_data = copy.deepcopy(_KG_1D_SPEC)
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = (  # type: ignore[index]
+            "1 + Sin[x[]]"
+        )
+        correction_spec = _make_spec(spec_data)
+        with pytest.raises(NotImplementedError, match="kinetic"):
+            solve_modal_pass1(
+                {},  # never read: the guard fires first
+                correction_spec,
+                self._grid(),
+                np.linspace(0.0, 1.0, 3),
+            )
+
+    # -- scheme resolution ----------------------------------------------
+
+    def test_resolve_scheme_intact_eh_stays_modal(self) -> None:
+        """THE campaign-flow regression pin: the intact perturbative EH
+        spec must keep auto-selecting modal, because eligibility is now
+        judged on the driver-style canonicalized base (constant
+        kinetics), not on plain base_spec() (which keeps them
+        position-dependent).
+        """
+        from tidal.cli._simulate import _resolve_scheme
+
+        spec = self._load_eh(strip_perturbation=False)
+        assert _resolve_scheme("auto", spec, self._grid(), None) == "modal"
+
+    def test_resolve_scheme_stripped_eh_routes_to_time_domain(self) -> None:
+        from tidal.cli._simulate import _resolve_scheme
+
+        spec = self._load_eh(strip_perturbation=True)
+        scheme = _resolve_scheme("auto", spec, self._grid(), None)
+        assert scheme in {"ida", "cvode"}  # both consume kinetics via grid=
+
+    def test_resolve_scheme_explicit_modal_rejected(self) -> None:
+        from tidal.cli._simulate import _resolve_scheme
+
+        spec = self._load_eh(strip_perturbation=True)
+        with pytest.raises(RuntimeError, match="kinetic"):
+            _resolve_scheme("modal", spec, self._grid(), None)
+
+    # -- the documented alternative actually works ----------------------
+
+    def test_stripped_eh_runs_under_cvode(self) -> None:
+        """The guard's alternative (a) must be real: the stripped EH spec
+        integrates under CVODE (which evaluates the position-dependent
+        kinetics on the grid, GH #382).
+        """
+        from tidal.solver.cvode import solve_cvode
+
+        spec = self._load_eh(strip_perturbation=True)
+        grid = self._grid()
+        layout = StateLayout.from_spec(spec, grid.num_points)
+        rng = np.random.default_rng(0)
+        y0 = 1e-3 * rng.standard_normal(layout.num_slots * grid.num_points)
+        result = solve_cvode(
+            spec,
+            grid,
+            y0,
+            (0.0, 0.1),
+            parameters=self.EH_PARAMS,
+            num_snapshots=3,
+        )
+        assert result["success"]
+        assert np.all(np.isfinite(result["y"]))

--- a/tidal/cli/_simulate.py
+++ b/tidal/cli/_simulate.py
@@ -1873,7 +1873,7 @@ def _has_time_dependent_coeffs(spec: EquationSystem) -> bool:
     return any(term.time_dependent for eq in spec.equations for term in eq.rhs_terms)
 
 
-def _resolve_scheme(  # noqa: C901
+def _resolve_scheme(  # noqa: C901, PLR0912
     scheme: str,
     spec: EquationSystem,
     grid: GridInfo | None = None,
@@ -1920,8 +1920,25 @@ def _resolve_scheme(  # noqa: C901
     # ValueError carries an actionable message — propagate it instead
     # of silently falling back to the full spec, which would make the
     # modal-eligibility check fail for an unrelated reason and mislead
-    # the user with "auto-selected: CVODE" (#277).
-    eligibility_spec = spec.base_spec() if spec.has_corrections() else spec
+    # the user with "auto-selected: CVODE" (#277).  KineticEvalError from
+    # canonicalization is a ValueError subclass, so the same contract
+    # covers it.
+    #
+    # GH #421: build the eligibility spec the way PerturbativeSolver
+    # actually will — canonicalize kinetics FIRST, then take the base.
+    # Plain base_spec() keeps a position-dependent kinetic whose
+    # non-constant part is entirely O(ε) (e.g. the Euler-Heisenberg
+    # dual-Gaussian spec), which would wrongly fail can_use_modal's
+    # kinetic check and silently de-select modal for a flow the
+    # perturbative driver handles fine.
+    if spec.has_corrections():
+        pert_meta = spec.metadata.get("perturbation", {}) or {}
+        small = list(pert_meta.get("small_parameters", []))
+        eligibility_spec = spec.canonicalize_kinetic_for_perturbation(small).base_spec(
+            small
+        )
+    else:
+        eligibility_spec = spec
 
     if scheme != "auto":
         if scheme in {"modal", "modal-jax"} and grid is not None:
@@ -1932,7 +1949,8 @@ def _resolve_scheme(  # noqa: C901
                 msg = (
                     f"--scheme {scheme} requested but system is not eligible. "
                     "Modal solver requires: flat metric, all-periodic BCs, "
-                    "time-independent coefficients, and supported spatial "
+                    "time-independent coefficients, constant (non-position-"
+                    "dependent) kinetic coefficients, and supported spatial "
                     "operators.  Use 'auto' or another solver."
                 )
                 raise RuntimeError(msg)

--- a/tidal/solver/modal.py
+++ b/tidal/solver/modal.py
@@ -356,6 +356,12 @@ def can_use_modal(
     3. All boundary conditions periodic
     4. All RHS operators have exact Fourier multipliers
     5. No time-dependent coefficients
+    6. No position-dependent kinetic coefficients (GH #421) — position-
+       dependent RHS coefficients are fine (handled via the ĉ(k−k′)
+       convolution paths), but a position-dependent M(x) needs the
+       mass-side convolution M̂(k−k′), which is not implemented (GH #427).
+       Auto-selection falls through to the time-domain backends, which
+       evaluate such kinetics on the grid (GH #382).
     """
     # 1. Flat metric — curved metrics have non-None volume_element
     if spec.canonical is not None and spec.canonical.volume_element is not None:
@@ -402,7 +408,49 @@ def can_use_modal(
             if term.time_dependent:
                 return False
 
-    return True
+    # 6. No position-dependent kinetic coefficients (GH #421).  Note this
+    # is checked on the ELIGIBILITY spec: for perturbative flows the CLI
+    # passes the canonicalized base spec, whose kinetics are constant even
+    # when the full spec's are position-dependent (GH #380) — so the EH
+    # dual-Gaussian campaign flow stays modal-eligible.
+    return not spec.has_position_dependent_kinetic()
+
+
+def _raise_position_dependent_kinetic(spec: EquationSystem, where: str) -> None:
+    """Raise the GH #421 refusal for a position-dependent kinetic coefficient.
+
+    Shared by the entry guards in :func:`solve_modal`,
+    :func:`solve_modal_pass1` and :func:`_build_evolution_matrices` so
+    every modal path (including the stability probe in
+    :mod:`tidal.measurement._stability`, which reaches
+    ``_build_evolution_matrices`` directly on every likelihood
+    evaluation) fails loudly with the same actionable message instead of
+    evaluating the kinetic without a grid (deep ValueError) or silently
+    falling back to M = 1 (the pre-guard genEig behavior).
+    """
+    posdep_fields = [
+        eq.field_name
+        for eq in spec.equations
+        if eq.time_derivative_order > 0 and eq.kinetic_position_dependent
+    ]
+    msg = (
+        f"{where} cannot handle a position-dependent kinetic coefficient "
+        f"(field(s) {posdep_fields}). A position-dependent M(x) is a "
+        "k-space convolution — the mass matrix becomes a mode-coupling "
+        "block M̂(k−k′), which the modal solver does not implement "
+        "(GH #427 tracks the feature; GH #421 is this guard). "
+        "Alternatives: (a) use --scheme cvode or --scheme ida — the "
+        "time-domain solvers evaluate position-dependent kinetics on the "
+        "grid (GH #382); (b) if the position-dependence is proportional "
+        "to a small parameter, declare it in [perturbation]."
+        "small_parameters so kinetic canonicalization moves it into O(ε) "
+        "RHS corrections and the base spec stays constant-coefficient "
+        "(GH #380, the Euler-Heisenberg flow); (c) if this spec has a "
+        "[perturbation] block but you passed --perturbative-order 0, the "
+        "full un-canonicalized spec is being solved on the plain modal "
+        "path — drop the override or use a time-domain scheme."
+    )
+    raise NotImplementedError(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -663,6 +711,18 @@ def _build_evolution_matrices(
 
     assert isinstance(coeff_eval, CoefficientEvaluator)
     logger = logging.getLogger(__name__)
+
+    # GH #421 guard AT THE BUILDER, not only at solve_modal: this builder
+    # has five production call sites (solve_modal, modal_jax, and three in
+    # tidal/measurement/_stability.py — the stability probe that gates
+    # every likelihood evaluation in an inference chain).  Without this
+    # check the inline kinetic evaluation below hits `except Exception`
+    # and silently proceeds with M = 1 — wrong physics with no error.
+    # NotImplementedError deliberately does NOT match the probe's
+    # (LinAlgError, ValueError) handler, so it propagates instead of
+    # being mislabeled "tachyonic".
+    if spec.has_position_dependent_kinetic():
+        _raise_position_dependent_kinetic(spec, "_build_evolution_matrices")
 
     n_modes = int(np.prod(rfft_shape))
 
@@ -2528,7 +2588,19 @@ def find_independent_blocks(
 
 
 def _has_position_dependent_terms(spec: EquationSystem) -> bool:
-    """Check if any RHS term has a position-dependent coefficient."""
+    """Check if any RHS term has a position-dependent coefficient.
+
+    Deliberately RHS-only: this is the ROUTING predicate that selects the
+    ĉ(k−k′) convolution builders over the constant-coefficient ones, and
+    those builders convolve RHS coefficients only.  Do NOT extend it to
+    ``kinetic_coefficient_symbolic`` — a position-dependent kinetic needs
+    the mass-side convolution M̂(k−k′) (GH #427), which no current path
+    implements, so routing on it would just move the failure into a
+    different builder.  Position-dependent kinetics are instead refused
+    up front by the GH #421 guards (see
+    :func:`_raise_position_dependent_kinetic`) and excluded from modal
+    eligibility by :func:`can_use_modal`.
+    """
     for eq in spec.equations:
         for term in eq.rhs_terms:
             if term.position_dependent:
@@ -3415,6 +3487,14 @@ def solve_modal(
             f"docs/PERTURBATIVE_REDUCTION_IMPLEMENTATION.md."
         )
         raise ValueError(msg)
+
+    # GH #421: refuse position-dependent kinetics before any matrices are
+    # built.  Redundant with the _build_evolution_matrices guard for the
+    # genEig path, but the per-mode/convolution builders would otherwise
+    # fail later with a grid-less evaluate_coefficient ValueError that
+    # names neither the cause nor a way out.
+    if spec.has_position_dependent_kinetic():
+        _raise_position_dependent_kinetic(spec, "solve_modal")
 
     layout = StateLayout.from_spec(spec, grid.num_points)
     coeff_eval = CoefficientEvaluator(spec, grid, parameters or {})
@@ -4361,6 +4441,15 @@ def solve_modal_pass1(
           the driver onto ``PerturbativeResult.validity`` (#272).
     """
     from tidal.solver.coefficients import CoefficientEvaluator  # noqa: PLC0415
+
+    # GH #421: the Pass 1 source builder consumes the correction spec's
+    # kinetic coefficients without a grid (`_build_source_matrix_k` has no
+    # grid parameter), so a position-dependent kinetic surviving into the
+    # corrections must be refused here rather than fail deep inside
+    # evaluate_coefficient.  Canonicalized flows (GH #380) never hit this:
+    # their correction kinetics are constants.
+    if correction_spec.has_position_dependent_kinetic():
+        _raise_position_dependent_kinetic(correction_spec, "solve_modal_pass1")
 
     layout = eigendata["state_layout"]
 

--- a/tidal/solver/perturbative_driver.py
+++ b/tidal/solver/perturbative_driver.py
@@ -447,26 +447,39 @@ class PerturbativeSolver:
             msg = (
                 "PerturbativeSolver requires a constant-coefficient base "
                 "(order_in_eps=0) spec. The provided theory has position-"
-                "dependent terms in the base spec even after kinetic "
-                "canonicalization — v6 Pass 1 Duhamel cannot evaluate "
-                "the augmented matrix exponential without per-mode "
-                "eigendata, which the Krylov expm_multiply path for "
-                "position-dependent systems does not provide. "
-                "Alternatives: (a) drop the [perturbation] block and run "
-                "plain modal (Krylov handles position-dependent base "
-                "directly, no perturbative correction); (b) use --scheme "
-                "cvode or --scheme ida (time-domain solvers integrate "
-                "position-dependent coefficients without modal restrictions). "
-                "If the position-dependence ought to be perturbative "
-                "(O(ε)) but is being tagged O(0), check the Wolfram "
-                "derivation's order_in_eps tagging — see GH #380 for the "
-                "kinetic-canonicalization case."
+                "dependent RHS terms or kinetic coefficients in the base "
+                "spec even after kinetic canonicalization — v6 Pass 1 "
+                "Duhamel cannot evaluate the augmented matrix exponential "
+                "without per-mode eigendata, which the Krylov "
+                "expm_multiply path for position-dependent systems does "
+                "not provide. Alternatives: (a) for position-dependent "
+                "RHS terms only, drop the [perturbation] block and run "
+                "plain modal (Krylov handles a position-dependent RHS "
+                "base directly, no perturbative correction) — NOT "
+                "available for a position-dependent kinetic, which modal "
+                "refuses outright (GH #421/#427); (b) use --scheme cvode "
+                "or --scheme ida (time-domain solvers integrate position-"
+                "dependent coefficients, kinetics included via GH #382, "
+                "without modal restrictions). If the position-dependence "
+                "ought to be perturbative (O(ε)) but is being tagged "
+                "O(0), check the Wolfram derivation's order_in_eps "
+                "tagging — see GH #380 for the kinetic-canonicalization "
+                "case."
             )
             raise NotImplementedError(msg)
 
     def _base_has_position_dependence(self) -> bool:
-        """Return True if base_spec has any position-dependent RHS term."""
+        """Return True if base_spec has position-dependent RHS terms or kinetics.
+
+        The kinetic check (GH #421) catches position-dependence that
+        survives canonicalization because it is NOT proportional to a
+        small parameter — i.e. genuinely O(ε⁰).  Without it the
+        construction-time guard stays silent and the failure surfaces
+        deep inside the modal builders instead.
+        """
         for eq in self.base_spec.equations:
+            if eq.kinetic_position_dependent:
+                return True
             for term in eq.rhs_terms:
                 if term.position_dependent:
                     return True

--- a/tidal/symbolic/json_loader.py
+++ b/tidal/symbolic/json_loader.py
@@ -749,6 +749,25 @@ class ComponentEquation:
             )
             raise ValueError(msg)
 
+    @property
+    def kinetic_position_dependent(self) -> bool:
+        """Whether the LHS kinetic coefficient depends on spatial coordinates.
+
+        Mirrors :attr:`OperatorTerm.position_dependent`: ``True`` when
+        ``kinetic_coefficient_symbolic`` contains a spatial coordinate call
+        such as ``x[]`` or ``y[]``; time-only dependence (``t[]``) returns
+        ``False``.  Solvers that evaluate the kinetic coefficient without a
+        grid (the modal builders — see GH #421) must refuse such equations
+        rather than evaluate at a single point or silently fall back to
+        M = 1.
+        """
+        if self.kinetic_coefficient_symbolic is None:
+            return False
+        return any(
+            m[0] != "t"
+            for m in _COORD_CALL_RE.findall(self.kinetic_coefficient_symbolic)
+        )
+
     @classmethod
     def from_dict(
         cls,
@@ -1323,6 +1342,23 @@ class EquationSystem:
         suffices.
         """
         return any(t.order_in_eps > 0 for eq in self.equations for t in eq.rhs_terms)
+
+    def has_position_dependent_kinetic(self) -> bool:
+        """Return True if any dynamical equation has a position-dependent kinetic.
+
+        Restricted to dynamical equations (``time_derivative_order > 0``) —
+        consumer-faithful to :func:`tidal.solver._kinetic.build_inverse_kinetic_diag`,
+        which skips constraint rows.  Used by the modal solver's eligibility
+        check and entry guards (GH #421): a position-dependent ``M(x)`` is a
+        k-space convolution ``M̂(k−k′)``, which modal does not implement
+        (GH #427); the time-domain backends handle it via ``grid=``
+        (GH #382).
+        """
+        return any(
+            eq.kinetic_position_dependent
+            for eq in self.equations
+            if eq.time_derivative_order > 0
+        )
 
     def canonicalize_kinetic_for_perturbation(
         self,


### PR DESCRIPTION
Fixes #421. Option 2 of the issue (refuse clearly); the real M̂(k−k′) kinetic-convolution feature is tracked in #427.

## What was wrong

GH #382 taught `build_inverse_kinetic_diag` to evaluate position-dependent kinetics on a grid and wired `grid=` into the four time-domain backends — but never into the four modal builders. A position-dependent `kinetic_coefficient_symbolic` reaching modal:

- died with a cryptic grid-less `ValueError` ("name 'x' is not defined") on the per-mode and convolution paths, or
- **was silently treated as M ≡ 1** by `_build_evolution_matrices`'s `except Exception` swallow — wrong physics, no error. That builder has five production call sites, including three in `tidal/measurement/_stability.py`, whose probe gates every likelihood evaluation in an inference chain.

Auto-selection would happily route such a spec to modal (`can_use_modal` never inspected kinetics).

## The fix

- New predicate: `ComponentEquation.kinetic_position_dependent` + `EquationSystem.has_position_dependent_kinetic()` (dynamical equations only, consumer-faithful to `build_inverse_kinetic_diag`).
- `can_use_modal` requirement 6: position-dependent kinetics are not modal-eligible; position-dependent **RHS** stays eligible (existing convolution paths). Auto-selection falls through to IDA/CVODE, which handle these kinetics via `grid=`.
- **Make-or-break interaction handled:** `_resolve_scheme` now builds its eligibility spec driver-style (`canonicalize_kinetic_for_perturbation(small).base_spec(small)`). Plain `base_spec()` keeps O(ε) position-dependent kinetics, so the naive check would have silently de-selected modal for the working Euler-Heisenberg perturbative campaign flow — pinned by a regression test (intact EH spec still auto-selects modal; verified interactively too).
- `NotImplementedError` guards with actionable alternatives (--scheme cvode/ida; declare the dependence in `[perturbation].small_parameters`; check `--perturbative-order`) at `_build_evolution_matrices` (covers all five call sites; deliberately not caught by the stability probe's `(LinAlgError, ValueError)` handler, so it propagates instead of fabricating a "tachyonic" verdict), `solve_modal`, and `solve_modal_pass1`.
- `_base_has_position_dependence` (perturbative construction guard) now also checks kinetics — an O(ε⁰) position-dependent kinetic previously slipped it.
- `_has_position_dependent_terms` stays deliberately RHS-only (it routes to the ĉ(k−k′) builders, which convolve RHS coefficients only) with a comment explaining why.

## Tests

17 new tests (`TestGH421PositionDependentKinetic`, `TestGH421BaseKineticGuard`): predicate semantics (constant / t[]-only / constraint-row exclusion), eligibility both ways, all three entry guards, stability-probe propagation (raise, not silent M≡1; constant-kinetic probe stays green), scheme resolution (stripped → ida, intact perturbative EH → modal, explicit modal → RuntimeError), perturbative construction guard (O(ε⁰) refused / O(ε) canonicalized), and a CVODE smoke run proving the documented alternative works. Targeted suites green (320 passed: modal + perturbative + kinetic-consistency + CLI).

## Found while testing (filed separately)

- #428 — call-form kinetics (`Sin[x[]]`) crash `lhs_collapses_to_zero` with an AST error before any guard can classify them.
- #429 — the EH dual-Gaussian spec cannot complete `tidal simulate` on main at any nonzero rho: the pre-existing Pass-1 cross-block guard uses an absolute 1e-14 threshold. Reproduces identically pre/post this change.

Version bump deferred until this and #426 merge (avoids colliding 0.48.8 bumps across parallel PRs).