### PR TITLE
feat(inference): estimator-surface hardening — noise-floor flags (#433) + arctan bounds warning (#425)

### DIFF
--- a/docs/dkl_recompute_report.md
+++ b/docs/dkl_recompute_report.md
@@ -646,6 +646,14 @@ Ranking (most→least constrained): old `rho > sigma` → new `sigma > rho` — 
   couplings on regeneration.
 - The wider `hpc_results/` set (115 runs with affected prior kinds) keeps its
   pre-fix `importance.json`; recompute on demand when any of them is quoted.
+  **Staleness tell**: a pre-v0.48.8 `importance.json` has no `consistency`
+  block — if that key is absent, the marginals were computed with the broken
+  estimator and must not be quoted. (`tidal analyze <dir> --inference
+  --importance` recomputes live with the fixed estimator; the joint D_KL,
+  log Z and d_G in the same file were always correct.) Audited consumers:
+  the corner-plot headline quotes only the joint `d_kl` (safe), the
+  `plot_importance` bar chart always receives a freshly-computed result
+  (safe), and `tidal/inference/_atlas.py` does not read marginals at all.
 
 ## Caveats
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -111,6 +111,25 @@ class TestPrior:
         assert p.transform(0.0) < -10
         assert p.transform(1.0) > 10
 
+    def test_arctan_uniform_warns_bounds_ignored(self) -> None:
+        """GH #425: arctan_uniform ignores low/high — construction must say
+        so instead of letting the bounds masquerade as the support.
+        """
+        import math as _math
+
+        from tidal.inference._prior import _ARCTAN_EPS, Prior
+
+        with pytest.warns(UserWarning, match="ignores its bounds"):
+            Prior("x", "arctan_uniform", -89.0, 89.0)
+        # Bounds matching the implied support do not warn.
+        support = _math.tan(_math.pi / 2 - _ARCTAN_EPS)
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            Prior("x", "arctan_uniform", -support, support)
+            Prior("x", "uniform", -89.0, 89.0)  # other kinds never warn
+
     def test_invalid_distribution(self) -> None:
         from tidal.inference._prior import Prior
 
@@ -1471,6 +1490,94 @@ class TestMarginalDKLPriorTransforms:
             },
         )
         assert "WARNING" not in format_importance_table(healthy)
+
+    # -- noise-floor awareness (#433) ----------------------------------
+
+    def test_low_n_eff_marks_floor_dominated(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A chain whose weights concentrate on ~20 samples has a
+        per-parameter noise floor of ~(40-1)/(2*20) ≈ 1 nat — every
+        floor-level marginal must be flagged, not ranked (the T9 rescue
+        chain failure mode).
+        """
+        pytest.importorskip("anesthetic")
+        import logging
+
+        from tidal.inference._importance import compute_parameter_importance
+        from tidal.inference._prior import Prior
+        from tidal.inference._results import InferenceResult
+
+        rng = np.random.default_rng(5)
+        n, nlive = 2000, 100
+        prior = Prior(name="x", distribution="uniform", low=-1.0, high=1.0)
+        x = prior.sample(rng, n)
+        # Steep logL ramp → nested weights concentrate on the top handful
+        # of samples → tiny Kish n_eff, mimicking a floor-contaminated
+        # rescue chain.
+        log_l = 50.0 * np.linspace(0.0, 1.0, n) ** 8
+        result = InferenceResult(
+            samples=x[:, None],
+            log_likelihood=log_l,
+            log_prior=np.zeros(n),
+            param_names=["x"],
+            method="nested",
+            log_evidence=0.0,
+            log_evidence_err=0.1,
+            weights=np.ones(n) / n,
+            metadata={"sampler": "test", "nlive": nlive, "priors": [prior]},
+        )
+        with caplog.at_level(logging.WARNING, logger="tidal.inference"):
+            imp = compute_parameter_importance(result, n_bootstrap=10)
+
+        cons = imp.consistency
+        assert cons["n_eff"] < 200, "fixture failed to concentrate weights"
+        assert "noise_floor" in cons
+        assert cons["noise_floor"]["x"] == pytest.approx(
+            39.0 / (2 * cons["n_eff"]), rel=1e-9
+        )
+        # The uniform-prior marginal of a prior-distributed column is pure
+        # estimator bias here, so it must be flagged floor-dominated.
+        assert cons["floor_dominated_params"] == ["x"]
+        assert "noise floor" in caplog.text
+
+        from tidal.inference._importance import format_importance_table
+
+        table = format_importance_table(imp)
+        assert "(<= floor)" in table
+        assert "do not rank" in table
+
+    def test_healthy_n_eff_no_floor_warning(self) -> None:
+        """Equal-weight, large-N chains must not trip the floor flag."""
+        pytest.importorskip("anesthetic")
+        from tidal.inference._importance import (
+            compute_parameter_importance,
+            format_importance_table,
+        )
+        from tidal.inference._prior import Prior
+        from tidal.inference._results import InferenceResult
+
+        rng = np.random.default_rng(6)
+        n, nlive = 6000, 1000
+        prior = Prior(name="x", distribution="uniform", low=-1.0, high=1.0)
+        # Genuinely constrained posterior (narrow normal inside the prior)
+        # with flat-ish logL ordering so weights stay broad.
+        x = np.clip(rng.normal(0.0, 0.05, n), -0.999, 0.999)
+        log_l = -0.5 * (x / 0.05) ** 2
+        result = InferenceResult(
+            samples=x[:, None],
+            log_likelihood=log_l,
+            log_prior=np.zeros(n),
+            param_names=["x"],
+            method="nested",
+            log_evidence=0.0,
+            log_evidence_err=0.1,
+            weights=np.ones(n) / n,
+            metadata={"sampler": "test", "nlive": nlive, "priors": [prior]},
+        )
+        imp = compute_parameter_importance(result, n_bootstrap=10)
+        assert imp.consistency["floor_dominated_params"] == []
+        assert "(<= floor)" not in format_importance_table(imp)
 
 
 # ===================================================================

--- a/tidal/inference/_importance.py
+++ b/tidal/inference/_importance.py
@@ -75,14 +75,19 @@ class ParameterImportanceResult:
     log_evidence_err : float
         Bootstrap uncertainty on log Z.
     consistency : dict[str, Any]
-        Self-check diagnostics for the marginal estimates (#420):
+        Self-check diagnostics for the marginal estimates (#420/#433):
         ``sum_marginals``, ``superadditivity_ok`` (for a product prior
         the chain rule gives ``D_KL(joint) >= sum of marginals`` exactly,
         so a violating sum means the estimator is broken),
         ``product_prior`` (whether the bound is exact for this run),
         ``saturated_params`` (marginals within 90% of the histogram
-        ceiling ``log(n_bins)`` — resolution-limited values), and
-        ``note``.  Empty dict when marginals could not be computed.
+        ceiling ``log(n_bins)`` — resolution-limited values), ``n_eff``
+        (Kish effective sample size of the posterior weights),
+        ``noise_floor`` (per-parameter estimator bias
+        ``(n_bins - 1)/(2 n_eff)`` — a marginal at or below its floor is
+        noise, not constraint), ``floor_dominated_params`` (the names
+        that fail that test), and ``note``.  Empty dict when marginals
+        could not be computed.
     """
 
     param_names: list[str]
@@ -480,6 +485,7 @@ def compute_parameter_importance(
 
     saturated: list[str] = []
     bias_numerator = 0.0  # accumulates (n_bins - 1) / 2 per finite marginal
+    bins_by_param: dict[str, int] = {}  # bins used per finite marginal (#433)
     for i, name in enumerate(result.param_names):
         try:
             col = np.asarray(ns.iloc[:, i])
@@ -526,6 +532,7 @@ def compute_parameter_importance(
             marginal_d_kl[name] = kl
             if np.isfinite(kl):
                 bias_numerator += (bins_used - 1) / 2.0
+                bins_by_param[name] = bins_used
                 if kl > 0.9 * float(np.log(bins_used)):
                     saturated.append(name)
         except (ValueError, ZeroDivisionError, AttributeError, IndexError) as exc:
@@ -557,6 +564,19 @@ def compute_parameter_importance(
     bias_allowance = 2.0 * bias_numerator / n_eff
     tolerance = 3.0 * d_kl_err + bias_allowance + 0.05
     superadditivity_ok = sum_marginals <= d_kl + tolerance
+    # Per-parameter noise floor (#433): the histogram marginal is biased up
+    # by ~(n_bins - 1)/(2 n_eff), so a marginal at or below its floor is
+    # estimator noise, not evidence the parameter is constrained.  This is
+    # how the floor-contaminated rescue chains (n_eff as low as 21)
+    # masqueraded as ranked per-coupling signal.
+    noise_floor = {
+        name: (bins - 1) / (2.0 * n_eff) for name, bins in bins_by_param.items()
+    }
+    floor_dominated = [
+        name
+        for name, kl in marginal_d_kl.items()
+        if name in noise_floor and np.isfinite(kl) and kl <= noise_floor[name]
+    ]
     consistency: dict[str, Any] = {
         "sum_marginals": sum_marginals,
         "joint_d_kl": d_kl,
@@ -569,11 +589,14 @@ def compute_parameter_importance(
         # marginal read as spuriously informative.  Recorded so readers
         # can judge whether small marginals are signal or floor.
         "n_eff": n_eff,
+        "noise_floor": noise_floor,
+        "floor_dominated_params": floor_dominated,
         "note": (
             "sum(marginals) <= joint D_KL is exact for product priors; "
             "approximate when a radial_angular joint prior is present. "
             "Saturated marginals are within 90% of the histogram ceiling "
-            "log(n_bins) and are resolution-limited."
+            "log(n_bins) and are resolution-limited. Marginals at or below "
+            "their noise_floor entry are estimator noise, not constraint."
         ),
     }
     if not superadditivity_ok:
@@ -592,6 +615,14 @@ def compute_parameter_importance(
             "marginal D_KL consistency: %s within 90%% of the estimator "
             "ceiling log(n_bins) — resolution-limited, treat as lower bounds",
             ", ".join(saturated),
+        )
+    if floor_dominated:
+        logger.warning(
+            "marginal D_KL consistency: %s at or below the noise floor "
+            "(n_bins-1)/(2*n_eff) with n_eff = %.0f — estimator noise, not "
+            "constraint; do not rank these parameters (see #433)",
+            ", ".join(floor_dominated),
+            n_eff,
         )
 
     return ParameterImportanceResult(
@@ -697,11 +728,17 @@ def format_importance_table(result: ParameterImportanceResult) -> str:
     """Format parameter importance as a human-readable table.
 
     Parameters are ranked by marginal D_KL (most constrained first).
+    Rows whose marginal sits at or below the per-parameter noise floor
+    ``(n_bins - 1)/(2 n_eff)`` are annotated ``(<= floor)`` — such values
+    are estimator noise, not evidence of constraint (#433).
     """
     import math
 
     lines: list[str] = []
     lines.extend(("", "--- Parameter Importance (KL Divergence) ---", ""))
+
+    consistency = result.consistency or {}
+    noise_floor: dict[str, float] = consistency.get("noise_floor") or {}
 
     # Rank by marginal D_KL (descending)
     ranked = sorted(
@@ -726,6 +763,9 @@ def format_importance_table(result: ParameterImportanceResult) -> str:
             importance = "moderate"
         else:
             importance = "weak"
+        floor = noise_floor.get(name)
+        if floor is not None and math.isfinite(dkl) and dkl <= floor:
+            importance = f"{importance} (<= floor)"
         lines.append(f"  {name:<20} {dkl:>12.4f}  {importance:>12}")
 
     lines.extend(
@@ -738,9 +778,8 @@ def format_importance_table(result: ParameterImportanceResult) -> str:
         ),
     )
 
-    # Consistency self-checks (#420): make a broken estimator visible in the
-    # table itself, not just in the log.
-    consistency = result.consistency or {}
+    # Consistency self-checks (#420/#433): make a broken or under-sampled
+    # estimator visible in the table itself, not just in the log.
     if consistency and not consistency.get("superadditivity_ok", True):
         lines.extend(
             (
@@ -757,6 +796,17 @@ def format_importance_table(result: ParameterImportanceResult) -> str:
             (
                 f"  WARNING: {', '.join(saturated)} at the histogram "
                 "resolution ceiling — treat as lower bounds",
+                "",
+            ),
+        )
+    floor_dominated = consistency.get("floor_dominated_params") or []
+    if floor_dominated:
+        n_eff = consistency.get("n_eff", float("nan"))
+        lines.extend(
+            (
+                f"  WARNING: {', '.join(floor_dominated)} at or below the "
+                f"noise floor (n_eff = {n_eff:.0f}) — estimator noise, not "
+                "constraint; do not rank (see #433)",
                 "",
             ),
         )

--- a/tidal/inference/_prior.py
+++ b/tidal/inference/_prior.py
@@ -40,8 +40,22 @@ class Prior:
         ``"arctan_uniform"``.
     low : float
         Lower bound (for uniform/log_uniform) or mean (for normal).
+        **Ignored for arctan_uniform** — see below.
     high : float
         Upper bound (for uniform/log_uniform) or std (for normal).
+        **Ignored for arctan_uniform** — see below.
+
+    Notes
+    -----
+    ``arctan_uniform`` does NOT use ``low``/``high`` (GH #425): the angle
+    is uniform on the fixed eps-truncated range
+    ``(-pi/2 + _ARCTAN_EPS, +pi/2 - _ARCTAN_EPS)``, so the support is
+    always ``|x| <= tan(pi/2 - _ARCTAN_EPS) ~= 19.98`` regardless of the
+    recorded bounds.  A ``UserWarning`` fires at construction when the
+    given bounds differ from that implied support.  Honoring the bounds
+    would silently redefine the prior for every archived chain whose
+    metadata records these unused numbers, so any change must be
+    versioned — deliberately deferred, see the options in GH #425.
     """
 
     name: str
@@ -63,6 +77,28 @@ class Prior:
         if self.distribution == "normal" and self.high <= 0:
             msg = f"Normal prior std must be positive, got {self.high}"
             raise ValueError(msg)
+        if self.distribution == "arctan_uniform":
+            # GH #425: sample/transform/log_prob use the fixed eps-truncated
+            # theta range and ignore low/high entirely.  Tell the user at
+            # launch rather than let the recorded bounds masquerade as the
+            # support (which is how the #420 marginal D_KL inflation got a
+            # (-89, 89) histogram range for a +-20 distribution).
+            import warnings
+
+            support = math.tan(math.pi / 2 - _ARCTAN_EPS)
+            if not (
+                math.isclose(self.low, -support, rel_tol=1e-9)
+                and math.isclose(self.high, support, rel_tol=1e-9)
+            ):
+                warnings.warn(
+                    f"arctan_uniform ignores its bounds: requested "
+                    f"[{self.low}, {self.high}] but the sampled support is "
+                    f"fixed at [-{support:.2f}, {support:.2f}] "
+                    f"(theta uniform on +-(pi/2 - {_ARCTAN_EPS})). "
+                    f"See GH #425.",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
     # ------------------------------------------------------------------
     # Sampling (Monte Carlo)
@@ -154,7 +190,8 @@ def parse_prior(spec: str) -> Prior:
         "alpha=uniform:0.01:10"
         "xi=log_uniform:0.01:10"
         "delta=normal:0:1"
-        "alpha=arctan_uniform:-30:30"
+        "alpha=arctan_uniform:-30:30"   # bounds recorded but IGNORED:
+                                        # support is fixed at ~+-20 (GH #425)
 
     Raises
     ------


### PR DESCRIPTION
Stacked on #431 (needs its `n_eff` consistency field). Retarget to main after #431 merges.

Estimator-surface hardening so the failure classes found during the #420 remediation self-report:

## Noise-floor awareness (#433, option 3)

- `consistency` gains `noise_floor` (per-parameter `(n_bins − 1)/(2·n_eff)`) and `floor_dominated_params`.
- `compute_parameter_importance` warns when any marginal sits at or below its floor, naming `n_eff`; `format_importance_table` annotates those rows `(<= floor)` and prints a do-not-rank warning.
- This is the guard that would have flagged the T9 rescue chain (n_eff = 21 → ~0.9-nat floor) before its per-coupling numbers were ever tabulated. **Re-runs of the affected chains are deferred to a future campaign** — the present goal is a pipeline that reports the condition itself.

## arctan bounds (#425, option 3 — document-only + warning)

- `Prior`/`parse_prior` docstrings now state that arctan_uniform ignores `low`/`high` (support fixed at ±tan(π/2 − 0.05) ≈ ±19.98), and construction emits a `UserWarning` when the given bounds differ from the implied support.
- Option 1 (honor the bounds behind a schema marker) deliberately deferred — it would silently redefine the prior recorded by 100+ archived chains; the issue documents the versioned route.

## Staleness tell (#432 support)

- Report note: a pre-v0.48.8 `importance.json` lacks the `consistency` block — that absence marks broken-estimator marginals. Consumer audit came back clean (atlas: no marginal usage; corner headline: joint D_KL only; `plot_importance`: fresh computation) — posted to #432.

## Tests

3 new (`test_low_n_eff_marks_floor_dominated`, `test_healthy_n_eff_no_floor_warning`, `test_arctan_uniform_warns_bounds_ignored`); full `tests/test_inference.py`: 88 passed. ruff/pyright/cspell clean.

Closes #425. #433 closes here too unless a future-campaign re-run is preferred to keep it open as a tracker — flagging for the merge decision.