### PR TITLE
Land the approved #435 + #436 stack onto main

### DIFF
--- a/CAMPAIGN.md
+++ b/CAMPAIGN.md
@@ -474,3 +474,43 @@ _(Filled in as results arrive)_
 | ----- | ------------------------------------------------------------------------------------- |
 | #296  | Euler-Heisenberg F⁴ extension (#271 resolved, defer EH theory to future)              |
 | #297  | Non-propagating/constraint torsion theories (single irreducible sector investigation) |
+
+---
+
+## 2026-08-18 Correction: marginal D_KL estimator (GH #420) — append-only amendment
+
+**Nothing above this line is edited; this entry records which earlier numbers are
+superseded and where the corrected ones live.** Full evidence:
+`docs/dkl_recompute_report.md`; living claim-status record:
+`docs/RESULTS_AMENDMENTS.md`; fixed in v0.48.8 (PR #426), chains recomputed
+(PR #431), estimator self-checks added (PR #435).
+
+- **Defect**: `compute_parameter_importance` only uniformized `log_uniform`
+  priors. Every **arctan_uniform** marginal D_KL recorded in this log's v3-era
+  entries (May 2026 onward: D1/Stage-A `*_v3`/`*_v3_pub`, T5–T9, NP controls,
+  EH+Gert) is inflated and saturated toward the log(40) ≈ 3.69 ceiling;
+  `radial_angular` (atlas) marginals fell to a self-referential fallback. The
+  **cross divergence D₊‖₋, joint D_KL, log Z, Bayes factors, d_G and all
+  uniform/log_uniform marginals are unaffected** — in particular the April-era
+  Stage-B/D2 entries above (uniform priors, e.g. "β₁ = 0.242 nats") are
+  mechanically unaffected by this bug.
+- **Corrected values**: per-chain old-vs-new tables (amp and sup) in
+  `docs/dkl_recompute_report.md`; claim-level status against the thesis tables in
+  `docs/RESULTS_AMENDMENTS.md`. Headline: 19 of 26 chain-directions change their
+  top-marginal coupling; corrected marginals now agree with the (unaffected)
+  D₊‖₋ rankings.
+- **Verdict-line status**: v3-era lines in this log quoting per-coupling marginal
+  D_KL against the 0.05/0.005 thresholds (`docs/campaign_plan.md:140-149`) should
+  be read through `docs/RESULTS_AMENDMENTS.md` rather than at face value. Lines
+  quoting log Z, Bayes factors, or D₊‖₋ stand as written.
+- **Floor caveat (GH #433)**: T7/T9/NP-ceven rescue chains have N_eff 21–248 →
+  per-parameter noise floors 0.08–0.93 nats; their per-coupling marginals are
+  estimator noise in both the original and corrected analyses. Re-runs deferred
+  to a future campaign; the pipeline now flags the condition
+  (`floor_dominated_params`).
+- **Prior provenance (GH #434)**: pre-schema chains (T5-NP, T6, T7, T9, NP-ceven)
+  were originally scored against fabricated all-arctan(±89) priors; T6/T7 in
+  fact used `xi = log_uniform:1e-3:1e3` (sbatch templates). Recompute now honors
+  per-chain `prior_overrides`.
+- **Issues**: #420 #425 #427 #428 #429 #432 #433 #434 (see also the
+  GitHub Issues table above — not edited, per append-only policy).

--- a/cspell.json
+++ b/cspell.json
@@ -485,6 +485,7 @@
     "undefines",
     "unfused",
     "Ungauged",
+    "uniformized",
     "uniformizing",
     "unphysical",
     "unphysically",

--- a/docs/RESULTS_AMENDMENTS.md
+++ b/docs/RESULTS_AMENDMENTS.md
@@ -1,0 +1,293 @@
+# Results Amendments
+
+**Purpose.** The thesis manuscript (`manuscript/`) is a frozen archive: it records
+what was claimed, on what evidence, at submission time, and is never edited. This
+document is the living record of amendments — what has since been superseded, what
+stands, and why — so the current state of results is always readable without
+rewriting history. Each amendment cites its evidence and the GitHub trail.
+`CAMPAIGN.md` mirrors each amendment as an append-only dated entry.
+
+Conventions: `stands` = the archived claim is supported by the corrected analysis;
+`superseded` = the archived number/claim is replaced by the corrected value here;
+`floor` = no claim is supportable either way at the chain's effective sample size;
+`strengthened` = the corrected analysis supports the archived claim more strongly.
+
+---
+
+## Amendment 1 (2026-08-18) — Marginal D_KL estimator correction (GH #420)
+
+### What happened
+
+`compute_parameter_importance` transformed only `log_uniform` priors into the space
+where the prior is uniform before histogramming. `arctan_uniform` columns (most
+campaign couplings) were scored in linear space against a uniform reference over
+recorded bounds the sampler never used, inflating and **saturating** marginals near
+the estimator ceiling log(40) ≈ 3.69 nats; `radial_angular` columns fell to a
+self-referential fallback. Fixed in v0.48.8 (PR #426); all 13 viable publication
+chains recomputed (PR #431); full evidence in `docs/dkl_recompute_report.md`.
+Two further defects were found and fixed during remediation: fabricated all-arctan
+priors for pre-schema chains (#434 — T7/T6 actually used log-uniform ξ per the
+sbatch templates) and a column-rename mismatch in the recompute script. The
+estimator now self-checks (superadditivity, saturation, noise floor, N_eff —
+GH #433).
+
+### What is affected, and what is not
+
+The archived per-coupling tables report three quantities per coupling. They are
+NOT equally affected:
+
+| quantity | symbol in the archive | status |
+|---|---|---|
+| amplification-only marginal D_KL | D+ | **superseded** — recomputed below |
+| suppression-only marginal D_KL | D− | **superseded** — recomputed below |
+| amplification-vs-suppression cross divergence | D₊‖₋ | **unchanged** (prior-free estimator, #420 never touched it) |
+
+Also unchanged and quotable directly from the archive: joint D_KL, log Z, Bayes
+factors, d_G (all anesthetic-computed), and every `uniform`/`log_uniform` marginal
+(bit-identical by construction; verified e.g. β₃ 0.0049 → 0.0049, ξ 1.20 → 1.20).
+
+**Load-bearing consequence:** most of the thesis's operator-identification prose
+keys on D₊‖₋, not on D+/D−, so those claims stand. Better: the corrected D+/D−
+marginals now largely *agree* with the D₊‖₋ rankings (e.g. EM-RC amp: corrected
+top coupling is δ₁, matching its D₊‖₋ = 20.8; Bahamonde: corrected top is ξ,
+matching D₊‖₋ = 5.55) — a coherence the broken estimator obscured. What is
+genuinely superseded is every quoted D+/D− number, plus the small set of claims
+that rested on marginal-to-marginal comparisons (see the claim table).
+
+### Claim-by-claim status (results.tex)
+
+| archive site | claim | basis | status |
+|---|---|---|---|
+| :203-207 | δ₁ an order of magnitude above the other couplings (D₊‖₋ = 20.8) | cross | stands |
+| :238-242 (`KLTableEMRCParityPair`) | D+/D− cells | marginal | superseded — corrected table below |
+| :278-284 | parity-even concentrates on δ₁ (20.8); parity-odd vertex drops to 8.8 and β₁/β₂ become comparable (5.44/4.35) | cross | stands |
+| :336-342 | each YM truncation concentrates D on a different operator: ξ (Bahamonde, Barker), β₁ (Shapiro), χ (union) | cross | stands; corrected marginals now agree (ξ tops Bahamonde/Barker amp) |
+| :422-430 (`KLTableYMUnified`) | D+/D− cells | marginal | superseded — corrected table below |
+| :457-465 | χ₁ dominant axis, largest D₊‖₋ = 4.2 | cross | stands (D+/D− cells floor-limited, see below) |
+| :536-541 | NP control matches YM union "within the bootstrap uncertainty of the per-coupling marginal D in every operator direction" | **marginal** | **superseded** — corrected marginals differ by up to 1.27 nats (sup χ: 1.43 propagating vs 0.17 NP; amp β₁: 0.05 vs 0.64), far beyond floor at N_eff ≈ 1100–2900. The qualitative control conclusion (amplification without propagating torsion) is separately supported by the corner overlays and log Z and is NOT withdrawn here, but this quantitative support line no longer holds; a future campaign should re-examine it |
+| :543-552 | same control claim at the parity-even closure (17D vs 18D) | marginal | floor — both chains have N_eff 80–248 (floors 0.08–0.24 nats); corrected differences ≤ 0.13 nats are within floor, so the comparison has no resolving power either way |
+| :554-559 | dominant operator: β₁ in the YM control, χ₁ in the closure control | cross | stands (corrected NP amp marginal also puts β₁ top, 0.64) |
+| :572-583 (`KLTableChiClosureComparison`) | D+/D− cells | marginal | superseded and floor-limited — corrected table below |
+| :633-643 | T9 kinetic closure "per-coupling D figures not quantitatively meaningful" (overflow) | — | **strengthened & quantified**: N_eff = 21 (amp), noise floor ≈ 0.93 nats/param — no per-coupling value in this sector is signal (GH #433) |
+| :756-765 | dark photon: Δm at 3.4 nats, m_A² at 1.5; "marginal D values … not directly cross-comparable" | cross (+ an archived caveat) | stands — the archived caveat anticipated exactly the per-prior-shape problem #420 fixed |
+| :786-789 (`KLTableDarkPhoton`) | D+/D− cells | marginal | superseded — corrected table below |
+| :836-846 | Euler-Heisenberg null: marginals "statistically indistinguishable from the prior" | marginal | **strengthened** — corrected marginals sit at the chain's noise floor (0.15–0.34 vs floor ≈ 0.19 at N_eff ≈ 104), i.e. no detectable information gain, and the joint D_KL ≈ 0.01 nats; the commented-out KLTableEH values 2.4–2.7 were pure estimator artifact |
+
+### Corrected per-coupling tables
+
+Values in nats; "archived" = as printed in the thesis tables (equal to the pre-fix
+`parameter_importance.json`, to rounding); "corrected" = post-#420 recompute
+(PR #431). `(≤ floor)` marks values at or below the chain's per-parameter noise
+floor `(n_bins−1)/(2·N_eff)` — estimator noise, not constraint (GH #433).
+
+### `KLTableEMRCParityPair`
+
+**Parity-even EM-RC (delta1)** (`hpc_results/29189748/d1_amp_v3`; N_eff amp/sup ≈ 5694/5224)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| beta1 | 3.18 | 0.52 | 2.87 | 0.27 | 0.71 |
+| beta2 | 2.94 | 0.15 | 2.77 | 0.26 | 0.54 |
+| beta3 | 0.00 | 0.00 | 0.15 | 0.15 | 0.20 |
+| delta1 | 1.43 | 1.86 | 3.00 | 0.77 | 20.78 |
+
+Top-3 by D+ (amp marginal): archived `beta1 > beta2 > delta1` → corrected `delta1 > beta1 > beta2`.
+
+**Parity-odd (d21)** (`hpc_results/29515407/t6_minimal_amp_v3`; N_eff amp/sup ≈ 944/642)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| beta1 | 3.00 | 0.59 | 3.10 | 1.76 | 5.44 |
+| beta2 | 3.10 | 0.66 | 3.40 | 1.63 | 4.35 |
+| beta3 | 2.53 | 0.08 | 2.57 | 0.53 | 0.81 |
+| d21 | 1.79 | 1.56 | 3.04 | 1.18 | 8.83 |
+
+Top-3 by D+ (amp marginal): archived `beta2 > beta1 > beta3` → corrected `d21 > beta2 > beta1`.
+
+### `KLTableYMUnified`
+
+**Bahamonde** (`hpc_results/29507332/d20_bahamonde_amp_v3_pub`; N_eff amp/sup ≈ 1063/2404)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| beta1 | 2.93 | 0.59 | 2.93 | 0.28 | 0.94 |
+| beta2 | 2.67 | 0.31 | 2.88 | 0.12 | 0.52 |
+| beta3 | 2.82 | 0.18 | 2.50 | 0.03 | 0.24 |
+| xi | 1.20 | 1.20 | 1.77 | 1.77 | 5.55 |
+| delta1 | 3.02 | 0.75 | 3.06 | 0.62 | 0.08 |
+
+Top-3 by D+ (amp marginal): archived `delta1 > beta1 > beta3` → corrected `xi > delta1 > beta1`.
+
+**Barker** (`hpc_results/29507332/d21_barker_amp_v3_pub`; N_eff amp/sup ≈ 1340/2895)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| beta1 | 2.36 | 0.42 | 2.83 | 0.16 | 1.30 |
+| beta2 | 2.66 | 0.11 | 2.65 | 0.08 | 0.21 |
+| beta3 | 2.97 | 0.25 | 2.55 | 0.01 | 0.22 |
+| xi | 2.65 | 0.92 | 1.59 | 1.59 | 4.87 |
+| delta1 | 3.09 | 0.76 | 2.98 | 0.61 | 0.52 |
+| chi | 3.00 | 1.02 | 3.11 | 1.92 | 0.64 |
+
+Top-3 by D+ (amp marginal): archived `delta1 > chi > beta3` → corrected `chi > xi > delta1`.
+
+**Shapiro** (`hpc_results/29468763/d22_shapiro_amp_v3`; N_eff amp/sup ≈ 1341/3302)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| beta1 | 2.37 | 0.14 | 3.04 | 0.40 | 4.77 |
+| beta2 | 2.48 | 0.03 | 2.83 | 0.14 | 1.14 |
+| beta3 | 2.62 | 0.10 | 2.74 | 0.11 | 0.32 |
+| xi | 0.15 | 0.15 | 0.44 | 0.44 | 0.53 |
+| delta1 | 2.87 | 0.12 | 2.94 | 0.21 | 0.20 |
+| zeta1 | 2.67 | 0.07 | 1.66 | 0.58 | 0.54 |
+| zeta2 | 2.96 | 0.15 | 2.97 | 0.26 | 0.16 |
+| zeta3 | 2.63 | 0.07 | 2.80 | 0.09 | 0.25 |
+
+Top-3 by D+ (amp marginal): archived `zeta2 > delta1 > zeta1` → corrected `zeta2 > xi > beta1`.
+
+**Union** (`hpc_results/29468763/d23_full_amp_v3`; N_eff amp/sup ≈ 1297/2870)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| beta1 | 2.56 | 0.05 | 2.80 | 0.41 | 0.77 |
+| beta2 | 2.47 | 0.04 | 2.64 | 0.18 | 0.44 |
+| beta3 | 2.63 | 0.05 | 2.61 | 0.03 | 0.13 |
+| xi | 0.18 | 0.18 | 0.31 | 0.31 | 0.40 |
+| delta1 | 2.93 | 0.11 | 2.71 | 0.06 | 0.17 |
+| chi | 2.31 | 0.15 | 3.01 | 1.43 | 3.86 |
+| zeta1 | 2.63 | 0.10 | 1.96 | 0.24 | 0.38 |
+| zeta2 | 2.81 | 0.11 | 2.86 | 0.09 | 0.25 |
+| zeta3 | 2.71 | 0.07 | 2.72 | 0.05 | 0.27 |
+
+Top-3 by D+ (amp marginal): archived `delta1 > zeta2 > zeta3` → corrected `xi > chi > delta1`.
+
+**NP control (xi=0)** (`hpc_results/29700462/np_amp_v1`; N_eff amp/sup ≈ 1146/2867)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| beta1 | 2.19 | 0.64 | 2.68 | 0.09 | 3.48 |
+| beta2 | 2.35 | 0.25 | 2.54 | 0.04 | 0.66 |
+| beta3 | 2.47 | 0.16 | 2.75 | 0.08 | 0.43 |
+| delta1 | 2.76 | 0.19 | 2.73 | 0.07 | 0.26 |
+| chi | 2.81 | 0.35 | 2.89 | 0.17 | 0.57 |
+| zeta1 | 2.82 | 0.31 | 2.56 | 0.04 | 0.23 |
+| zeta2 | 2.99 | 0.38 | 2.05 | 0.22 | 0.74 |
+| zeta3 | 2.76 | 0.26 | 2.26 | 0.11 | 0.43 |
+
+Top-3 by D+ (amp marginal): archived `zeta2 > zeta1 > chi` → corrected `beta1 > zeta2 > chi`.
+
+### `KLTableChiClosureComparison`
+
+**NP control (17D)** (`hpc_results/29705560/np_ceven_amp_v1`; N_eff amp/sup ≈ 80/211)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| beta1 | 2.60 | 0.22 (≤ floor) | 2.76 | 0.10 | 0.57 |
+| beta2 | 2.50 | 0.29 | 2.68 | 0.09 | 0.77 |
+| beta3 | 2.47 | 0.29 | 2.54 | 0.08 (≤ floor) | 0.49 |
+| delta1 | 2.48 | 0.29 | 2.46 | 0.09 (≤ floor) | 0.85 |
+| zeta1 | 2.68 | 0.20 (≤ floor) | 2.51 | 0.10 | 0.31 |
+| zeta2 | 2.62 | 0.22 (≤ floor) | 2.51 | 0.09 (≤ floor) | 0.38 |
+| zeta3 | 2.30 | 0.26 | 2.47 | 0.08 (≤ floor) | 0.89 |
+| chi1 | 1.72 | 0.71 | 2.82 | 0.15 | 5.78 |
+| chi2 | 2.39 | 0.29 | 2.78 | 0.10 | 0.89 |
+| chi3 | 2.58 | 0.20 (≤ floor) | 2.45 | 0.12 | 0.76 |
+| chi4 | 2.50 | 0.20 (≤ floor) | 2.61 | 0.06 (≤ floor) | 0.63 |
+| chi5 | 2.68 | 0.19 (≤ floor) | 2.63 | 0.10 | 0.27 |
+| chi6 | 2.54 | 0.17 (≤ floor) | 2.61 | 0.08 (≤ floor) | 0.57 |
+| chi7 | 2.37 | 0.25 | 2.80 | 0.11 | 1.44 |
+| chi8 | 2.42 | 0.26 | 2.43 | 0.09 (≤ floor) | 0.96 |
+| chi9 | 2.55 | 0.21 (≤ floor) | 2.70 | 0.09 (≤ floor) | 0.49 |
+| chi10 | 2.72 | 0.25 | 2.54 | 0.07 (≤ floor) | 0.29 |
+
+Top-3 by D+ (amp marginal): archived `chi10 > zeta1 > chi5` → corrected `chi1 > delta1 > beta3`.
+
+**Propagating (18D)** (`hpc_results/29682868/t7_amp_v2`; N_eff amp/sup ≈ 118/248)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| beta1 | 2.59 | 0.22 | 2.73 | 0.10 | 0.52 |
+| beta2 | 2.67 | 0.18 | 2.73 | 0.09 | 0.46 |
+| beta3 | 2.68 | 0.16 (≤ floor) | 2.61 | 0.05 (≤ floor) | 0.40 |
+| xi | 2.45 | 0.18 | 2.38 | 0.09 | 0.44 |
+| delta1 | 2.55 | 0.20 | 2.53 | 0.07 (≤ floor) | 0.36 |
+| zeta1 | 2.72 | 0.20 | 2.60 | 0.08 (≤ floor) | 0.35 |
+| zeta2 | 2.51 | 0.12 (≤ floor) | 2.38 | 0.08 | 0.45 |
+| zeta3 | 2.37 | 0.19 | 2.43 | 0.08 | 0.42 |
+| chi1 | 1.68 | 0.67 | 2.82 | 0.12 | 4.18 |
+| chi2 | 2.37 | 0.22 | 2.66 | 0.06 (≤ floor) | 0.85 |
+| chi3 | 2.54 | 0.18 | 2.53 | 0.08 (≤ floor) | 0.47 |
+| chi4 | 2.40 | 0.16 (≤ floor) | 2.57 | 0.07 (≤ floor) | 0.85 |
+| chi5 | 2.74 | 0.15 (≤ floor) | 2.55 | 0.06 (≤ floor) | 0.22 |
+| chi6 | 2.50 | 0.18 | 2.68 | 0.08 (≤ floor) | 0.30 |
+| chi7 | 2.38 | 0.22 | 2.81 | 0.10 | 0.66 |
+| chi8 | 2.39 | 0.22 | 2.56 | 0.09 | 0.41 |
+| chi9 | 2.44 | 0.11 (≤ floor) | 2.70 | 0.09 | 0.78 |
+| chi10 | 2.56 | 0.22 | 2.43 | 0.09 | 0.37 |
+
+Top-3 by D+ (amp marginal): archived `chi5 > zeta1 > beta3` → corrected `chi1 > chi8 > beta1`.
+
+### `KLTableDarkPhoton`
+
+**Dark-photon plasma** (`hpc_results/29205968/stage_a_amp_v3_pub`; N_eff amp/sup ≈ 7443/10675)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| mA2 | 0.50 | 0.50 | 1.25 | 1.25 | 1.45 |
+| deltam | 2.77 | 0.17 | 2.98 | 1.46 | 3.38 |
+| xi | 0.85 | 0.85 | 1.24 | 1.24 | 0.00 |
+| alpha3 | 0.66 | 0.66 | 0.67 | 0.67 | 0.49 |
+
+Top-3 by D+ (amp marginal): archived `deltam > xi > alpha3` → corrected `xi > alpha3 > mA2`.
+
+### `KLTableEH (commented out in the archive)`
+
+**Euler-Heisenberg** (`hpc_results/29700083/eh_gert_amp_v1`; N_eff amp/sup ≈ 104/103)
+
+| coupling | D+ archived | D+ corrected | D− archived | D− corrected | D₊‖₋ (unchanged) |
+|---|---|---|---|---|---|
+| rho | 2.64 | 0.15 (≤ floor) | 2.70 | 0.24 | 0.45 |
+| sigma | 2.41 | 0.19 | 2.64 | 0.34 | 1.66 |
+
+Top-3 by D+ (amp marginal): archived `rho > sigma` → corrected `sigma > rho`.
+
+### Rescue-chain status (GH #433)
+
+T7 (chi_closure), T9 (xi_kinetic_closure) and the 17D NP control have effective
+sample sizes of 21–248, i.e. per-parameter noise floors of ~0.08–0.93 nats: **no
+per-coupling marginal from these chains is quotable as signal**, before or after
+the #420 fix. This sharpens the archive's own hedges (T9 was already marked "not
+quantitatively meaningful"). Re-runs with the overflow mitigations are explicitly
+deferred to a future campaign; the fixed pipeline now flags the condition
+automatically (`floor_dominated_params` in the consistency block, `(≤ floor)`
+annotations in the CLI table).
+
+### Provenance notes
+
+- Chains without recorded priors (pre-schema) are scored against priors
+  reconstructed from the committed sbatch templates (T7/T6: log-uniform ξ); a
+  one-time check against HPC submit logs would make this airtight
+  (`docs/dkl_recompute_report.md` caveats).
+- The ricci_em chain used a one-sided broad β₃ prior (GH #387): the β₃ row of
+  `KLTableEMRCParityPair` is not comparable across the parity pair, independent
+  of this amendment.
+- Staleness tell for anything outside the 13 recomputed chains: a
+  pre-v0.48.8 `importance.json` has no `consistency` block; recompute before
+  quoting (`tidal analyze <dir> --inference --importance`).
+
+### For a future campaign
+
+The estimator is fixed and self-checking in the pipeline (v0.48.8+); the
+amendments above are analysis-level only — no simulation was re-run. A future
+campaign should: re-run the floor-limited chains with overflow mitigations before
+making per-coupling claims there; re-examine the YM NP-control marginal-matching
+claim with healthy chains; use matched β priors for the parity pair (GH #387);
+and quote D+/D− only alongside the `consistency` block (N_eff, floors).
+
+### Trail
+
+GH #420 (estimator bug) · #425 (arctan bounds) · #426/#431/#435 (fix, recompute,
+hardening PRs) · #432 (this propagation) · #433 (noise floor) · #434 (fabricated
+priors) · `docs/dkl_recompute_report.md` (full evidence, per-chain tables,
+old-vs-new for both amp and sup directions).

--- a/docs/dkl_recompute_report.md
+++ b/docs/dkl_recompute_report.md
@@ -646,6 +646,14 @@ Ranking (most→least constrained): old `rho > sigma` → new `sigma > rho` — 
   couplings on regeneration.
 - The wider `hpc_results/` set (115 runs with affected prior kinds) keeps its
   pre-fix `importance.json`; recompute on demand when any of them is quoted.
+  **Staleness tell**: a pre-v0.48.8 `importance.json` has no `consistency`
+  block — if that key is absent, the marginals were computed with the broken
+  estimator and must not be quoted. (`tidal analyze <dir> --inference
+  --importance` recomputes live with the fixed estimator; the joint D_KL,
+  log Z and d_G in the same file were always correct.) Audited consumers:
+  the corner-plot headline quotes only the joint `d_kl` (safe), the
+  `plot_importance` bar chart always receives a freshly-computed result
+  (safe), and `tidal/inference/_atlas.py` does not read marginals at all.
 
 ## Caveats
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -111,6 +111,25 @@ class TestPrior:
         assert p.transform(0.0) < -10
         assert p.transform(1.0) > 10
 
+    def test_arctan_uniform_warns_bounds_ignored(self) -> None:
+        """GH #425: arctan_uniform ignores low/high — construction must say
+        so instead of letting the bounds masquerade as the support.
+        """
+        import math as _math
+
+        from tidal.inference._prior import _ARCTAN_EPS, Prior
+
+        with pytest.warns(UserWarning, match="ignores its bounds"):
+            Prior("x", "arctan_uniform", -89.0, 89.0)
+        # Bounds matching the implied support do not warn.
+        support = _math.tan(_math.pi / 2 - _ARCTAN_EPS)
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            Prior("x", "arctan_uniform", -support, support)
+            Prior("x", "uniform", -89.0, 89.0)  # other kinds never warn
+
     def test_invalid_distribution(self) -> None:
         from tidal.inference._prior import Prior
 
@@ -1471,6 +1490,94 @@ class TestMarginalDKLPriorTransforms:
             },
         )
         assert "WARNING" not in format_importance_table(healthy)
+
+    # -- noise-floor awareness (#433) ----------------------------------
+
+    def test_low_n_eff_marks_floor_dominated(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A chain whose weights concentrate on ~20 samples has a
+        per-parameter noise floor of ~(40-1)/(2*20) ≈ 1 nat — every
+        floor-level marginal must be flagged, not ranked (the T9 rescue
+        chain failure mode).
+        """
+        pytest.importorskip("anesthetic")
+        import logging
+
+        from tidal.inference._importance import compute_parameter_importance
+        from tidal.inference._prior import Prior
+        from tidal.inference._results import InferenceResult
+
+        rng = np.random.default_rng(5)
+        n, nlive = 2000, 100
+        prior = Prior(name="x", distribution="uniform", low=-1.0, high=1.0)
+        x = prior.sample(rng, n)
+        # Steep logL ramp → nested weights concentrate on the top handful
+        # of samples → tiny Kish n_eff, mimicking a floor-contaminated
+        # rescue chain.
+        log_l = 50.0 * np.linspace(0.0, 1.0, n) ** 8
+        result = InferenceResult(
+            samples=x[:, None],
+            log_likelihood=log_l,
+            log_prior=np.zeros(n),
+            param_names=["x"],
+            method="nested",
+            log_evidence=0.0,
+            log_evidence_err=0.1,
+            weights=np.ones(n) / n,
+            metadata={"sampler": "test", "nlive": nlive, "priors": [prior]},
+        )
+        with caplog.at_level(logging.WARNING, logger="tidal.inference"):
+            imp = compute_parameter_importance(result, n_bootstrap=10)
+
+        cons = imp.consistency
+        assert cons["n_eff"] < 200, "fixture failed to concentrate weights"
+        assert "noise_floor" in cons
+        assert cons["noise_floor"]["x"] == pytest.approx(
+            39.0 / (2 * cons["n_eff"]), rel=1e-9
+        )
+        # The uniform-prior marginal of a prior-distributed column is pure
+        # estimator bias here, so it must be flagged floor-dominated.
+        assert cons["floor_dominated_params"] == ["x"]
+        assert "noise floor" in caplog.text
+
+        from tidal.inference._importance import format_importance_table
+
+        table = format_importance_table(imp)
+        assert "(<= floor)" in table
+        assert "do not rank" in table
+
+    def test_healthy_n_eff_no_floor_warning(self) -> None:
+        """Equal-weight, large-N chains must not trip the floor flag."""
+        pytest.importorskip("anesthetic")
+        from tidal.inference._importance import (
+            compute_parameter_importance,
+            format_importance_table,
+        )
+        from tidal.inference._prior import Prior
+        from tidal.inference._results import InferenceResult
+
+        rng = np.random.default_rng(6)
+        n, nlive = 6000, 1000
+        prior = Prior(name="x", distribution="uniform", low=-1.0, high=1.0)
+        # Genuinely constrained posterior (narrow normal inside the prior)
+        # with flat-ish logL ordering so weights stay broad.
+        x = np.clip(rng.normal(0.0, 0.05, n), -0.999, 0.999)
+        log_l = -0.5 * (x / 0.05) ** 2
+        result = InferenceResult(
+            samples=x[:, None],
+            log_likelihood=log_l,
+            log_prior=np.zeros(n),
+            param_names=["x"],
+            method="nested",
+            log_evidence=0.0,
+            log_evidence_err=0.1,
+            weights=np.ones(n) / n,
+            metadata={"sampler": "test", "nlive": nlive, "priors": [prior]},
+        )
+        imp = compute_parameter_importance(result, n_bootstrap=10)
+        assert imp.consistency["floor_dominated_params"] == []
+        assert "(<= floor)" not in format_importance_table(imp)
 
 
 # ===================================================================

--- a/tidal/inference/_importance.py
+++ b/tidal/inference/_importance.py
@@ -75,14 +75,19 @@ class ParameterImportanceResult:
     log_evidence_err : float
         Bootstrap uncertainty on log Z.
     consistency : dict[str, Any]
-        Self-check diagnostics for the marginal estimates (#420):
+        Self-check diagnostics for the marginal estimates (#420/#433):
         ``sum_marginals``, ``superadditivity_ok`` (for a product prior
         the chain rule gives ``D_KL(joint) >= sum of marginals`` exactly,
         so a violating sum means the estimator is broken),
         ``product_prior`` (whether the bound is exact for this run),
         ``saturated_params`` (marginals within 90% of the histogram
-        ceiling ``log(n_bins)`` — resolution-limited values), and
-        ``note``.  Empty dict when marginals could not be computed.
+        ceiling ``log(n_bins)`` — resolution-limited values), ``n_eff``
+        (Kish effective sample size of the posterior weights),
+        ``noise_floor`` (per-parameter estimator bias
+        ``(n_bins - 1)/(2 n_eff)`` — a marginal at or below its floor is
+        noise, not constraint), ``floor_dominated_params`` (the names
+        that fail that test), and ``note``.  Empty dict when marginals
+        could not be computed.
     """
 
     param_names: list[str]
@@ -480,6 +485,7 @@ def compute_parameter_importance(
 
     saturated: list[str] = []
     bias_numerator = 0.0  # accumulates (n_bins - 1) / 2 per finite marginal
+    bins_by_param: dict[str, int] = {}  # bins used per finite marginal (#433)
     for i, name in enumerate(result.param_names):
         try:
             col = np.asarray(ns.iloc[:, i])
@@ -526,6 +532,7 @@ def compute_parameter_importance(
             marginal_d_kl[name] = kl
             if np.isfinite(kl):
                 bias_numerator += (bins_used - 1) / 2.0
+                bins_by_param[name] = bins_used
                 if kl > 0.9 * float(np.log(bins_used)):
                     saturated.append(name)
         except (ValueError, ZeroDivisionError, AttributeError, IndexError) as exc:
@@ -557,6 +564,19 @@ def compute_parameter_importance(
     bias_allowance = 2.0 * bias_numerator / n_eff
     tolerance = 3.0 * d_kl_err + bias_allowance + 0.05
     superadditivity_ok = sum_marginals <= d_kl + tolerance
+    # Per-parameter noise floor (#433): the histogram marginal is biased up
+    # by ~(n_bins - 1)/(2 n_eff), so a marginal at or below its floor is
+    # estimator noise, not evidence the parameter is constrained.  This is
+    # how the floor-contaminated rescue chains (n_eff as low as 21)
+    # masqueraded as ranked per-coupling signal.
+    noise_floor = {
+        name: (bins - 1) / (2.0 * n_eff) for name, bins in bins_by_param.items()
+    }
+    floor_dominated = [
+        name
+        for name, kl in marginal_d_kl.items()
+        if name in noise_floor and np.isfinite(kl) and kl <= noise_floor[name]
+    ]
     consistency: dict[str, Any] = {
         "sum_marginals": sum_marginals,
         "joint_d_kl": d_kl,
@@ -569,11 +589,14 @@ def compute_parameter_importance(
         # marginal read as spuriously informative.  Recorded so readers
         # can judge whether small marginals are signal or floor.
         "n_eff": n_eff,
+        "noise_floor": noise_floor,
+        "floor_dominated_params": floor_dominated,
         "note": (
             "sum(marginals) <= joint D_KL is exact for product priors; "
             "approximate when a radial_angular joint prior is present. "
             "Saturated marginals are within 90% of the histogram ceiling "
-            "log(n_bins) and are resolution-limited."
+            "log(n_bins) and are resolution-limited. Marginals at or below "
+            "their noise_floor entry are estimator noise, not constraint."
         ),
     }
     if not superadditivity_ok:
@@ -592,6 +615,14 @@ def compute_parameter_importance(
             "marginal D_KL consistency: %s within 90%% of the estimator "
             "ceiling log(n_bins) — resolution-limited, treat as lower bounds",
             ", ".join(saturated),
+        )
+    if floor_dominated:
+        logger.warning(
+            "marginal D_KL consistency: %s at or below the noise floor "
+            "(n_bins-1)/(2*n_eff) with n_eff = %.0f — estimator noise, not "
+            "constraint; do not rank these parameters (see #433)",
+            ", ".join(floor_dominated),
+            n_eff,
         )
 
     return ParameterImportanceResult(
@@ -697,11 +728,17 @@ def format_importance_table(result: ParameterImportanceResult) -> str:
     """Format parameter importance as a human-readable table.
 
     Parameters are ranked by marginal D_KL (most constrained first).
+    Rows whose marginal sits at or below the per-parameter noise floor
+    ``(n_bins - 1)/(2 n_eff)`` are annotated ``(<= floor)`` — such values
+    are estimator noise, not evidence of constraint (#433).
     """
     import math
 
     lines: list[str] = []
     lines.extend(("", "--- Parameter Importance (KL Divergence) ---", ""))
+
+    consistency = result.consistency or {}
+    noise_floor: dict[str, float] = consistency.get("noise_floor") or {}
 
     # Rank by marginal D_KL (descending)
     ranked = sorted(
@@ -726,6 +763,9 @@ def format_importance_table(result: ParameterImportanceResult) -> str:
             importance = "moderate"
         else:
             importance = "weak"
+        floor = noise_floor.get(name)
+        if floor is not None and math.isfinite(dkl) and dkl <= floor:
+            importance = f"{importance} (<= floor)"
         lines.append(f"  {name:<20} {dkl:>12.4f}  {importance:>12}")
 
     lines.extend(
@@ -738,9 +778,8 @@ def format_importance_table(result: ParameterImportanceResult) -> str:
         ),
     )
 
-    # Consistency self-checks (#420): make a broken estimator visible in the
-    # table itself, not just in the log.
-    consistency = result.consistency or {}
+    # Consistency self-checks (#420/#433): make a broken or under-sampled
+    # estimator visible in the table itself, not just in the log.
     if consistency and not consistency.get("superadditivity_ok", True):
         lines.extend(
             (
@@ -757,6 +796,17 @@ def format_importance_table(result: ParameterImportanceResult) -> str:
             (
                 f"  WARNING: {', '.join(saturated)} at the histogram "
                 "resolution ceiling — treat as lower bounds",
+                "",
+            ),
+        )
+    floor_dominated = consistency.get("floor_dominated_params") or []
+    if floor_dominated:
+        n_eff = consistency.get("n_eff", float("nan"))
+        lines.extend(
+            (
+                f"  WARNING: {', '.join(floor_dominated)} at or below the "
+                f"noise floor (n_eff = {n_eff:.0f}) — estimator noise, not "
+                "constraint; do not rank (see #433)",
                 "",
             ),
         )

--- a/tidal/inference/_prior.py
+++ b/tidal/inference/_prior.py
@@ -40,8 +40,22 @@ class Prior:
         ``"arctan_uniform"``.
     low : float
         Lower bound (for uniform/log_uniform) or mean (for normal).
+        **Ignored for arctan_uniform** — see below.
     high : float
         Upper bound (for uniform/log_uniform) or std (for normal).
+        **Ignored for arctan_uniform** — see below.
+
+    Notes
+    -----
+    ``arctan_uniform`` does NOT use ``low``/``high`` (GH #425): the angle
+    is uniform on the fixed eps-truncated range
+    ``(-pi/2 + _ARCTAN_EPS, +pi/2 - _ARCTAN_EPS)``, so the support is
+    always ``|x| <= tan(pi/2 - _ARCTAN_EPS) ~= 19.98`` regardless of the
+    recorded bounds.  A ``UserWarning`` fires at construction when the
+    given bounds differ from that implied support.  Honoring the bounds
+    would silently redefine the prior for every archived chain whose
+    metadata records these unused numbers, so any change must be
+    versioned — deliberately deferred, see the options in GH #425.
     """
 
     name: str
@@ -63,6 +77,28 @@ class Prior:
         if self.distribution == "normal" and self.high <= 0:
             msg = f"Normal prior std must be positive, got {self.high}"
             raise ValueError(msg)
+        if self.distribution == "arctan_uniform":
+            # GH #425: sample/transform/log_prob use the fixed eps-truncated
+            # theta range and ignore low/high entirely.  Tell the user at
+            # launch rather than let the recorded bounds masquerade as the
+            # support (which is how the #420 marginal D_KL inflation got a
+            # (-89, 89) histogram range for a +-20 distribution).
+            import warnings
+
+            support = math.tan(math.pi / 2 - _ARCTAN_EPS)
+            if not (
+                math.isclose(self.low, -support, rel_tol=1e-9)
+                and math.isclose(self.high, support, rel_tol=1e-9)
+            ):
+                warnings.warn(
+                    f"arctan_uniform ignores its bounds: requested "
+                    f"[{self.low}, {self.high}] but the sampled support is "
+                    f"fixed at [-{support:.2f}, {support:.2f}] "
+                    f"(theta uniform on +-(pi/2 - {_ARCTAN_EPS})). "
+                    f"See GH #425.",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
     # ------------------------------------------------------------------
     # Sampling (Monte Carlo)
@@ -154,7 +190,8 @@ def parse_prior(spec: str) -> Prior:
         "alpha=uniform:0.01:10"
         "xi=log_uniform:0.01:10"
         "delta=normal:0:1"
-        "alpha=arctan_uniform:-30:30"
+        "alpha=arctan_uniform:-30:30"   # bounds recorded but IGNORED:
+                                        # support is fixed at ~+-20 (GH #425)
 
     Raises
     ------


### PR DESCRIPTION
Mechanical landing PR — no new content. #435 (estimator hardening) and #436 (results amendments) were approved and merged, but into their stacked base branches rather than main (GitHub only retargets a stacked PR when its base branch is deleted on merge, and the branches were kept). Main therefore has only #431; this PR carries the already-reviewed remainder:

- `ca1bd499` feat(inference): noise-floor flags (#433) — reviewed in #435
- `d7c97588` fix(inference): arctan bounds warning (#425) — reviewed in #435
- `01c84217` docs: staleness tell + consumer audit — reviewed in #435
- `9c77eb91` docs: RESULTS_AMENDMENTS.md + append-only CAMPAIGN entry — reviewed in #436

The auto-close keywords in #435/#436 did not fire (they only trigger on merges into the default branch), so:

Closes #425
Closes #432
Closes #433

After merging, all three feature branches (`chore/420-dkl-recompute`, `feat/433-floor-aware-importance`, `docs/432-dkl-amendments`) can be deleted; I'll then bump the version on main.