### PR TITLE
fix(solver): make Pass-1 cross-block guard purely scale-relative (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ commits reworked a load-bearing part of the Wolfram pipeline that future
 maintainers need to be able to trace. Earlier versions are not
 retroactively covered; see `git log` for the full history.
 
+## [Unreleased]
+
+### Fixed
+
+- **Pass-1 cross-block guard is now purely scale-relative (#429)**. The
+  floored-relative threshold `max(1e-14, max|M_src|·1e-10)` introduced for
+  #275 (recorded below under v0.33.x) let the absolute floor dominate
+  whenever `max|M_src| < 1e-4`, silently passing — and then discarding —
+  cross-block source coupling that is a large fraction of the source norm.
+  The EH dual-Gaussian spec's physical O(ε) a_0↔a_3 coupling (~3% of the
+  source norm at Phase E geometry, where max|M_src| ≈ 8e-15) was masked
+  this way; the May 2026 "Pass 0 + Pass 1 complete end-to-end" runs were
+  therefore silently wrong, and the corresponding claim in
+  `docs/PHASE_E_TRACKER.md` is retracted. The threshold is now
+  `max|M_src|·1e-10` with no absolute floor: the spec refuses honestly at
+  every ρ, the refusal message names the coupled sectors, and sub-tolerance
+  discards are logged. Cross-block support is tracked in #439; the related
+  corner-collapse of position-dependent source coefficients in #438.
+
 ## [v0.34.0 – v0.47.9] — not individually recorded
 
 Changelog maintenance lapsed during the PGT survey campaign and the MSci

--- a/docs/PERTURBATIVE_REDUCTION_IMPLEMENTATION.md
+++ b/docs/PERTURBATIVE_REDUCTION_IMPLEMENTATION.md
@@ -325,8 +325,12 @@ The remediation plan (`.claude/plans/flickering-gathering-orbit.md`, approved
   surfaced on `PerturbativeResult.validity["correction_drops"]` (#272);
   `order >= 2` raises `NotImplementedError` with #273 reference;
   `base_spec`/`filter_by_order`/`normalize_kinetic_coefficients` recompute
-  mass/coupling matrices (#274); cross-block threshold is scale-relative
-  `max(1e-14, max|M|·1e-10)` (#275).
+  mass/coupling matrices (#274); cross-block threshold made floored-relative
+  `max(1e-14, max|M|·1e-10)` (#275 — note: the threshold work is #275, not
+  #274; the adjacency here caused a mis-citation in #429). The absolute
+  1e-14 floor was later found to mask physical cross-block coupling whenever
+  `max|M_src| < 1e-4` (the EH dual-Gaussian regime) and was removed in #429 —
+  the threshold is now purely scale-relative `max|M_src|·1e-10`.
 - **R2 (typed contracts)** bd8f3ae: `PerturbativePass1Result` TypedDict
   replaces `# type: ignore` smuggling (#279); `PerturbativeResult` carries
   `spec` + `full_spec`, CLI reads `pert_result.spec` instead of rebinding

--- a/docs/PHASE_E_TRACKER.md
+++ b/docs/PHASE_E_TRACKER.md
@@ -59,7 +59,7 @@
 ### Stage 1 — Wolfram derivations (interleaved with Stage 2+)
 
 - [x] 1.1 E.cal `gertsenshtein/theory_ungauged_e_dual_gaussian.toml` (~5 min — DONE; 14 components, 73KB JSON; PASS verdict on stability diagnostics, P/h0² ≈ 0.0036 matches Boccaletti sin²(0.063) ≈ 0.0039 within ~10%)
-- [x] 1.1b E.EH `euler_heisenberg/theory_e_dual_gaussian.toml` — **UNBLOCKED**: derivation (#378) and modal-perturbative simulation (#380) both fixed. Wolfram now keeps the small-param-bearing kinetic coefficient un-normalized (ExportJSON.wl), letting Python's existing `canonicalize_kinetic_for_perturbation` split M = M₀ + εM₁ and synthesize Pass-1 corrections. Modal Pass 0 + Pass 1 complete end-to-end. Tachyonic eigenvalue at t≥10 is a pre-existing physics property of Maxwell in this dual-Gaussian B background (present at ρ=σ=0); separate from the solver blocker. Non-blocking for the PGT roster.
+- [x] 1.1b E.EH `euler_heisenberg/theory_e_dual_gaussian.toml` — derivation (#378) fixed; Wolfram keeps the small-param-bearing kinetic coefficient un-normalized (ExportJSON.wl), letting Python's existing `canonicalize_kinetic_for_perturbation` split M = M₀ + εM₁ and synthesize Pass-1 corrections (#380). **RETRACTED (2026-08-19, #429): the earlier "Modal Pass 0 + Pass 1 complete end-to-end" claim was wrong.** Those runs passed the cross-block guard only because its absolute 1e-14 floor exceeded the entire source norm (max|M_src| ≈ 8e-15 at Phase E geometry) — the O(ε) a_0↔a_3 coupling (~3% of the source norm) was silently discarded, and the pos-dep Gaussian correction coefficients were corner-collapsed (#438). Post-#429 the perturbative route refuses honestly at all ρ (cross-block support tracked in #439). Tachyonic eigenvalue at t≥10 remains a pre-existing physics property of Maxwell in this dual-Gaussian B background (present at ρ=σ=0). E.EH stays DEFERRED; the order-0 (non-perturbative) modal route depends on #427.
 - [x] 1.2 E.T1 `dark_photon_plasma/theory_e_dual_gaussian.toml` — DONE (26 fields, 86 H terms)
 - [x] 1.3 E.T2 `torsion_gertsenshtein/theory_einstein_cartan_e_dual_gaussian.toml` — DONE (38 fields, 82 H terms; smoke PASS)
 - [x] 1.4 E.T4 `torsion_gertsenshtein/theory_nonminimal_e_dual_gaussian.toml` — DONE (38 fields, 82 H terms)
@@ -122,7 +122,7 @@ Stability column: `PASS` / `SOFT-PENALIZED` / `CATASTROPHIC`.
 | Stage | Theory | Derivation | Corner amp | Corner sup | Atlas | Stability | Verdict |
 |-------|--------|------------|------------|------------|-------|-----------|---------|
 | E.cal | gertsenshtein_ungauged | ☑ (2026-05-24) | ☑ local (no free params) | n/a | n/a (positive control) | PASS | calibration ✓ |
-| E.EH  | Euler-Heisenberg + EM (σ, ρ) | ☑ (derived but solver-blocked) | n/a | n/a | n/a | DEFERRED | DEFERRED — see #378 |
+| E.EH  | Euler-Heisenberg + EM (σ, ρ) | ☑ (derived but solver-blocked) | n/a | n/a | n/a | DEFERRED | DEFERRED — Pass 1 refuses honestly (#429; support: #439); order-0 modal needs #427 |
 | E.T1  | DP-plasma | ☑ (26 fields) | ☐ jobid | ☐ jobid | ☐ jobid | — | — |
 | E.T2  | Einstein-Cartan minimal | ☑ (38 fields) | ☐ **29640051** running | ☐ jobid | ☐ jobid | — | — |
 | E.T4  | Ricci-EM nonminimal (δ₁) | ☑ (38 fields) | ☐ jobid | ☐ jobid | n/a (1D) | — | — |

--- a/docs/tex/troubleshooting.tex
+++ b/docs/tex/troubleshooting.tex
@@ -425,6 +425,40 @@ per equation via \texttt{ComponentEquation.kinetic\_position\_dependent}).  The
 only shipped spec with position-dependent kinetics is
 \texttt{examples/data/euler\_heisenberg\_e\_dual\_gaussian.json}.
 
+\subsubsection{NotImplementedError: Pass 1 source matrix couples blocks}
+\label{sec:troubleshooting-pass1-cross-block}
+
+\textbf{Symptom:}
+\begin{lstlisting}[style=python]
+NotImplementedError: Pass 1 source matrix couples blocks that Pass 0 evolved
+independently: block ['a_0', 'v_a_0'] is sourced by out-of-block slot(s)
+['a_3', 'v_a_3'] (max|cross|=... > ..., relative to max|M_src|=...) ...
+\end{lstlisting}
+from \texttt{\_evolve\_duhamel\_per\_mode} during a perturbative
+(\texttt{[perturbation]}-block) run.
+
+\textbf{Root cause:} The $O(\varepsilon)$ correction terms source one Pass-0
+block from another (for the Euler--Heisenberg dual-Gaussian spec this is the
+physical $a_0 \leftrightarrow a_3$ coupling, $\sim$3\% of the source norm at
+Phase~E geometry).  The per-mode Duhamel kernel evolves Pass-0 blocks
+independently and cannot represent cross-block sources; the alternative would
+be silently discarding them, which is what happened before the guard's
+threshold was made purely scale-relative (GH~\#429) --- the earlier absolute
+$10^{-14}$ floor masked the coupling whenever the source scale was small.
+The refusal is structural (the coupling ratio is independent of the small
+parameter): reducing $\rho$ does not make the spec eligible.
+
+\textbf{Fix (one of):}
+\begin{itemize}
+  \item Run the full spec on a time-domain scheme: \texttt{--scheme cvode} or
+    \texttt{--scheme ida}.
+  \item Solve the full spec non-perturbatively on plain modal with
+    \texttt{--perturbative-order 0} (requires modal support for the full
+    spec's coefficients; for position-dependent kinetics see GH~\#427).
+  \item Cross-block Pass-1 support (merged Pass-0 partitioning) is tracked in
+    GH~\#439.
+\end{itemize}
+
 
 \subsection{Debugging Techniques}
 \label{sec:debugging-techniques}

--- a/tests/test_modal_duhamel.py
+++ b/tests/test_modal_duhamel.py
@@ -546,6 +546,143 @@ class TestCrossBlockCouplingRaises:
         with pytest.raises(NotImplementedError, match="[Cc]ross-block"):
             _evolve_duhamel_per_mode(eigendata, m_src_by_order, t_eval, layout, grid)
 
+    def test_cross_block_guard_not_masked_by_tiny_source_scale(self) -> None:
+        """GH #429: a tiny source scale must not mask physical coupling.
+
+        The pre-#429 threshold ``max(1e-14, max|M_src|·1e-10)`` had an
+        absolute floor that dominated whenever ``max|M_src| < 1e-4``,
+        silently passing (and then discarding) cross-block entries that
+        are a large FRACTION of the source — the EH dual-Gaussian at
+        Phase E geometry had ``max|M_src| ≈ 8e-15`` with cross-block
+        coupling at 3% of that norm. The threshold is now purely
+        scale-relative, so the same ratio refuses at any overall scale.
+        """
+        from tidal.solver.modal import (
+            _evolve_duhamel_per_mode,
+        )
+
+        base_data = copy.deepcopy(_CROSS_BLOCK_SPEC)
+        phi_eq = base_data["equations"][0]  # type: ignore[index]
+        phi_eq["rhs"]["terms"] = [  # type: ignore[index]
+            t
+            for t in phi_eq["rhs"]["terms"]  # type: ignore[reportUnknownVariableType]
+            if t.get("order_in_eps", 0) == 0
+        ]
+        base_spec = _make_spec(base_data)
+        n_grid = 16
+        length = 2 * np.pi
+        grid = GridInfo(shape=(n_grid,), bounds=((0.0, length),), periodic=(True,))
+        layout = StateLayout.from_spec(base_spec, grid.num_points)
+
+        x = np.linspace(0.0, length, n_grid, endpoint=False)
+        y0 = np.zeros(layout.num_slots * grid.num_points)
+        y0[:n_grid] = np.sin(x)  # phi_0
+        y0[2 * n_grid : 3 * n_grid] = 0.5 * np.sin(x)  # chi_0
+
+        pass0 = cast(
+            "dict[str, Any]",
+            solve_modal(
+                base_spec,
+                grid,
+                y0,
+                t_span=(0.0, 0.5),
+                parameters={"mPhi2": 1.0, "mChi2": 2.0},
+                num_snapshots=3,
+                return_eigendata=True,
+            ),
+        )
+        eigendata = pass0["eigendata"]
+        n_slots = layout.num_slots
+        rfft_last = grid.shape[-1] // 2 + 1
+        n_modes = int(np.prod([*grid.shape[:-1], rfft_last]))
+        m_src = np.zeros((n_modes, n_slots, n_slots), dtype=np.complex128)
+        blocks = eigendata["blocks"]
+        assert len(blocks) >= 2
+        b0_idx = int(blocks[0]["slot_indices"][0])
+        b1_idx = int(blocks[1]["slot_indices"][0])
+        # EH-like magnitudes: source scale 8e-15, cross entries 3% of it.
+        # Both sit far below the old absolute floor (1e-14), which passed
+        # them silently; the relative threshold (8e-25) must refuse.
+        m_src[:, b0_idx, b0_idx] = 8e-15
+        m_src[:, b0_idx, b1_idx] = 2.5e-16
+
+        with pytest.raises(NotImplementedError, match="[Cc]ross-block"):
+            _evolve_duhamel_per_mode(eigendata, {0: m_src}, pass0["t"], layout, grid)
+
+
+class TestGH429EHDualGaussianRefusal:
+    """GH #429: the EH dual-Gaussian spec refuses Pass 1 at ANY rho.
+
+    The cross-block coupling (O(ε) sources linking the a_0 and a_3
+    sectors at ~3% of the source norm, ratio independent of rho) is
+    physical, so the refusal must not depend on the overall source
+    scale. Pre-#429 the absolute floor made the verdict a function of
+    rho (refusing only for rho ≳ 1e-9 at this geometry).
+    """
+
+    EH_SPEC = "examples/data/euler_heisenberg_e_dual_gaussian.json"
+    SMALL = ["rho", "sigma"]
+
+    def _params(self, rho: float) -> dict[str, float]:
+        return {
+            "Bpeak": 0.01,
+            "rho": rho,
+            "sigma": 1e-6,
+            "sigB": 0.4,
+            "zc1": -1.5,
+            "zc2": 1.5,
+        }
+
+    @pytest.mark.parametrize("rho", [1e-9, 1.0])
+    def test_pass1_refuses_at_any_rho(self, rho: float) -> None:
+        import json
+        from pathlib import Path
+
+        raw = json.loads(Path(self.EH_SPEC).read_text(encoding="utf-8"))
+        spec = EquationSystem.from_dict(raw)
+        canon = spec.canonicalize_kinetic_for_perturbation(self.SMALL)
+        base = canon.base_spec(self.SMALL)
+        correction = canon.filter_by_order(1)
+
+        grid = GridInfo(shape=(32,), bounds=((-2.0, 2.0),), periodic=(True,))
+        layout = StateLayout.from_spec(base, grid.num_points)
+        params = self._params(rho)
+
+        # Excite every field slot so no block is pruned by the zero-IC
+        # skip (the guard verdict is IC-dependent, GH #440); the refusal
+        # must be structural, not an artifact of which blocks survive.
+        rng = np.random.default_rng(429)
+        y0 = np.zeros(layout.num_slots * grid.num_points)
+        for name, slot in layout.field_slot_map.items():
+            del name
+            sl = layout.slot_slice(slot)
+            y0[sl] = 1e-3 * rng.standard_normal(grid.num_points)
+
+        pass0 = cast(
+            "dict[str, Any]",
+            solve_modal(
+                base,
+                grid,
+                y0,
+                t_span=(0.0, 1.0),
+                parameters=params,
+                num_snapshots=3,
+                return_eigendata=True,
+            ),
+        )
+        with pytest.raises(NotImplementedError, match="[Cc]ross-block") as excinfo:
+            solve_modal_pass1(
+                pass0["eigendata"],
+                correction,
+                grid,
+                pass0["t"],
+                parameters=params,
+            )
+        # The message names the coupled sectors.
+        msg = str(excinfo.value)
+        assert "a_0" in msg
+        assert "a_3" in msg
+
 
 class TestPass1NearDegeneracy:
     """R5.3 / #282: Pass 1 Duhamel kernel in the Taylor-branch regime.

--- a/tidal/solver/modal.py
+++ b/tidal/solver/modal.py
@@ -4236,7 +4236,11 @@ def _evolve_duhamel_per_mode(
     Higham, N.J. (2009). "The scaling and squaring method for the matrix
     exponential revisited." *SIAM Review* 51(4):747-764.
     """
+    import logging  # noqa: PLC0415
+
     import scipy.linalg as sla  # type: ignore[import-untyped]  # noqa: PLC0415
+
+    logger = logging.getLogger(__name__)
 
     n_slots = layout.num_slots
     n_pts = layout.num_points
@@ -4257,7 +4261,8 @@ def _evolve_duhamel_per_mode(
 
     y_hat_snap = np.zeros((n_snapshots, n_slots, n_modes), dtype=np.complex128)
 
-    # Cross-block scale (same threshold logic as the legacy implementation).
+    # Cross-block scale: the guard below compares off-block source entries
+    # against a tolerance RELATIVE to this global source magnitude.
     m_scale_total = 0.0
     for _M_n in M_src_k_by_order.values():
         if _M_n.size:
@@ -4287,27 +4292,61 @@ def _evolve_duhamel_per_mode(
         # Cross-block coupling check: any non-zero in M_src_n's rows of this
         # block but columns outside it would mean Pass 1 mixes Pass 0 sectors
         # that were independent. Pass 0's block decomposition cannot represent
-        # that — raise early. Threshold is scale-relative (see #275).
+        # that — raise early. Threshold is PURELY scale-relative (#429): the
+        # former absolute 1e-14 floor (`max(1e-14, rel)`) masked *physical*
+        # coupling whenever max|M_src| < 1e-4 — the EH dual-Gaussian spec at
+        # Phase E geometry has max|M_src| ~ 8e-15, so the floor exceeded the
+        # entire source by ~10 orders while the intra-block slicing below
+        # silently discarded a 3%-of-norm coupling. Schur-tail roundoff
+        # (#275) scales WITH max|M_src|, so the relative form still tolerates
+        # it (pinned by test_cross_block_guard_tolerates_schur_tail_noise).
         mask = np.ones(n_slots, dtype=bool)
         mask[idx] = False
-        cross_max = 0.0
+        out_cols = np.flatnonzero(mask)
+        # Max |entry| per out-of-block column, over modes/rows/orders — used
+        # both for the verdict and to name the offending slots on refusal.
+        col_max = np.zeros(out_cols.size)
         for M_n in M_src_k_by_order.values():
-            if M_n.size == 0:
+            if M_n.size == 0 or out_cols.size == 0:
                 continue
-            full_rows_n = M_n[:, idx, :]
-            cross_n = full_rows_n[:, :, mask]
-            if cross_n.size > 0:
-                cross_max = max(cross_max, float(np.max(np.abs(cross_n))))
-        atol = max(1e-14, m_scale_total * 1e-10)
+            cross_n = np.abs(M_n[:, idx, :][:, :, out_cols])
+            col_max = np.maximum(col_max, cross_n.max(axis=(0, 1)))
+        cross_max = float(col_max.max()) if col_max.size else 0.0
+        atol = m_scale_total * 1e-10
         if cross_max > atol:
+            in_names = [layout.slots[i].name for i in slot_indices]
+            offending = [
+                layout.slots[int(c)].name
+                for c, mag in zip(out_cols, col_max, strict=True)
+                if mag > atol
+            ]
             msg = (
                 f"Pass 1 source matrix couples blocks that Pass 0 evolved "
-                f"independently (max|cross|={cross_max:.3e} > {atol:.3e}). "
-                f"Cross-block coupling is not supported — the correction "
-                f"theory likely mixes previously-independent sectors, which "
-                f"Pass 0 cannot represent. Report this spec to the TIDAL team."
+                f"independently: block {in_names} is sourced by "
+                f"out-of-block slot(s) {offending} "
+                f"(max|cross|={cross_max:.3e} > {atol:.3e}, relative to "
+                f"max|M_src|={m_scale_total:.3e}). Coupling above the "
+                f"roundoff tolerance means the correction theory mixes "
+                f"sectors Pass 0 evolved separately, which the per-mode "
+                f"Duhamel kernel cannot represent (GH #439 tracks "
+                f"cross-block support). Alternatives: run the full spec on "
+                f"a time-domain scheme (--scheme cvode or --scheme ida), "
+                f"or solve the full spec on plain modal with "
+                f"--perturbative-order 0 (requires modal support for the "
+                f"full spec's coefficients; see GH #427)."
             )
             raise NotImplementedError(msg)
+        if cross_max > 0.0:
+            # Sub-tolerance entries are roundoff by construction (anything
+            # physical raises above); note the discard for auditability
+            # since the intra-block slicing below drops them silently.
+            logger.info(
+                "Pass 1: discarding sub-roundoff cross-block entries for "
+                "block %s (max|cross|=%.3e <= atol=%.3e)",
+                [layout.slots[i].name for i in slot_indices],
+                cross_max,
+                atol,
+            )
 
         # Build the effective source S = Σ_n M_src_n · Aⁿ per mode, where
         # A = M_block. For the augmented form, S absorbs the time-derivative


### PR DESCRIPTION
## Summary

Closes #429.

The Pass-1 cross-block guard's threshold `max(1e-14, max|M_src|·1e-10)` let
the absolute floor dominate whenever `max|M_src| < 1e-4`, silently passing —
and then discarding via the intra-block slicing — cross-block source coupling
that is a large fraction of the source norm. For the EH dual-Gaussian spec the
O(ε) a_0↔a_3 coupling (~3.1% of the source norm, ρ-independent ratio) is
**physical**, so the observed "refuses at any ρ ≳ 1e-7" boundary was an
artifact of the floor, and every historical run that passed the guard was
silently wrong (see the retraction in `docs/PHASE_E_TRACKER.md`).

Full investigation record: https://github.com/WilliamRoyce/tidal/issues/429#issuecomment-5341721285

## Changes

- `_evolve_duhamel_per_mode`: threshold is now purely scale-relative
  (`max|M_src|·1e-10`); refusal message names the coupled in-block and
  out-of-block slots and points at time-domain schemes, order-0 plain modal
  (#427), and #439; sub-tolerance discards are logged.
- Tests: tiny-source-scale refusal (previously silent under the floor);
  EH dual-Gaussian refuses at ρ=1e-9 and ρ=1.0 alike with a_0/a_3 named;
  the #275 Schur-tail tolerance pin passes unchanged.
- Docs: PHASE_E_TRACKER retraction (E.EH stays DEFERRED),
  PERTURBATIVE_REDUCTION_IMPLEMENTATION wording (#274/#275 mis-citation),
  CHANGELOG corrective entry, troubleshooting.tex entry for the refusal.

## Follow-ups filed

- #438 — corner-collapse of position-dependent coefficients (probe + Pass-1
  sources); hardening lands with #427
- #439 — cross-block Pass-1 support via merged partitioning
- #440 — partition-threshold asymmetry + IC-dependent guard verdicts
- #441 — localized-background stability gate design

## Testing

- `tests/test_modal_duhamel.py` (15 passed) and `tests/test_solver_modal.py`
  (90 passed, 3 skipped combined) locally; full suite + ruff + pyright
  (0 errors on changed files) + cspell clean.
