### PR TITLE
fix(symbolic): call-form kinetics no longer crash lhs_collapses_to_zero (#428)

### DIFF
--- a/tests/test_kinetic_eval.py
+++ b/tests/test_kinetic_eval.py
@@ -21,6 +21,7 @@ import pytest
 
 from tidal.symbolic._kinetic_eval import (
     KineticEvalError,
+    _UnsupportedNodeError,
     evaluate_at_one,
     evaluate_at_zero,
     evaluate_with_substitutions,
@@ -151,6 +152,54 @@ class TestLhsCollapsesToZero:
         assert lhs_collapses_to_zero("2*b5 + 3*b1", ["b5", "b1"]) is True
         # Only b5 is small → 0 + 3*b1 = symbolic, does not collapse
         assert lhs_collapses_to_zero("2*b5 + 3*b1", ["b5"]) is False
+
+
+class TestGH428CallFormKinetics:
+    """GH #428: call-form kinetics must not crash the demotion predicate.
+
+    ``Sin[x[]]`` normalizes to ``Sin[x]`` (an ``ast.Subscript``), which the
+    safe evaluator cannot interpret. Pre-fix this escaped
+    ``lhs_collapses_to_zero`` as ``KineticEvalError: unsupported AST node``,
+    crashing ``EquationSystem.base_spec`` before the #421 position-dependence
+    guard could produce its actionable message. The predicate now treats
+    unsupported-but-parseable constructs as still-symbolic (no demotion);
+    strict evaluators keep raising.
+    """
+
+    def test_call_form_kinetic_no_demotion(self) -> None:
+        # The morally-identical power form "1 + x[]^2" already sailed
+        # through (still-symbolic → None → False); the call form must
+        # reach the same verdict instead of crashing.
+        assert lhs_collapses_to_zero("1 + Sin[x[]]", ["rho"]) is False
+
+    def test_python_call_form_no_demotion(self) -> None:
+        # ast.Call lands on the same unsupported-node raise.
+        assert lhs_collapses_to_zero("sin(b5)", ["b5"]) is False
+
+    def test_still_symbolic_coordinate_no_demotion(self) -> None:
+        # rho→0 leaves 0*x, still symbolic in x — no demotion. (Handled
+        # by the pre-existing still-symbolic path; pinned for contrast.)
+        assert lhs_collapses_to_zero("rho * x[]", ["rho"]) is False
+
+    def test_would_collapse_but_call_form_stays_conservative(self) -> None:
+        # rho→0 makes this mathematically 0·Sin(x) = 0, i.e. it WOULD
+        # collapse — but the call form is unsupported, so the predicate
+        # conservatively keeps the field dynamical. Later strict guards
+        # (the #421 position-dependence guard) classify it properly.
+        assert lhs_collapses_to_zero("rho * Sin[x[]]", ["rho"]) is False
+
+    def test_divide_by_zero_still_propagates(self) -> None:
+        # Genuine evaluation errors are NOT unsupported-node cases and
+        # must keep raising out of the predicate.
+        with pytest.raises(KineticEvalError, match="divide-by-zero"):
+            lhs_collapses_to_zero("1/rho", ["rho"])
+
+    def test_strict_evaluator_still_raises_on_call_form(self) -> None:
+        # The leniency lives in lhs_collapses_to_zero only; the strict
+        # evaluators (evaluate_at_zero/evaluate_at_one, #290 K_eff) keep
+        # raising, as the specific KineticEvalError subclass.
+        with pytest.raises(_UnsupportedNodeError, match="unsupported AST node"):
+            evaluate_at_zero("1 + Sin[x[]]", {"rho"})
 
 
 class TestEvaluateAtOne:

--- a/tests/test_perturbative_driver.py
+++ b/tests/test_perturbative_driver.py
@@ -1201,15 +1201,23 @@ class TestGH421BaseKineticGuard:
     failed deep inside the modal builders instead.
     """
 
-    def test_o_eps0_posdep_kinetic_refused_at_construction(self) -> None:
+    @pytest.mark.parametrize(
+        "kinetic",
+        [
+            # Power-form position dependence (mentions no small parameter,
+            # so it survives canonicalization into the base spec).
+            "1 + x[]^2",
+            # Call-form: pre-GH #428 this crashed lhs_collapses_to_zero
+            # with an AST-node KineticEvalError before the #421 guard
+            # could produce its actionable message; it must now reach the
+            # same refusal as the power form.
+            "1 + Sin[x[]]",
+        ],
+    )
+    def test_o_eps0_posdep_kinetic_refused_at_construction(self, kinetic: str) -> None:
         spec_data = copy.deepcopy(_KG_WITH_EPS)
-        # Power-form position dependence (mentions no small parameter, so
-        # it survives canonicalization into the base spec).  Call-form
-        # expressions like Sin[x[]] crash lhs_collapses_to_zero earlier
-        # with an unrelated KineticEvalError — a pre-existing gap tracked
-        # separately from #421.
         spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = (  # type: ignore[index]
-            "1 + x[]^2"
+            kinetic
         )
         spec = _make_spec(spec_data)
         with pytest.raises(NotImplementedError, match="kinetic"):

--- a/tidal/symbolic/_kinetic_eval.py
+++ b/tidal/symbolic/_kinetic_eval.py
@@ -52,6 +52,20 @@ class KineticEvalError(ValueError):
     """Raised when a kinetic coefficient string cannot be parsed safely."""
 
 
+class _UnsupportedNodeError(KineticEvalError):
+    """The expression contains a construct the safe evaluator cannot interpret.
+
+    Distinct from a construct that *evaluated* to an error (divide-by-zero,
+    ``0 ** negative``), which stays a plain :class:`KineticEvalError`.
+    Wolfram call-form expressions like ``Sin[x[]]`` normalize to ``Sin[x]``
+    (an ``ast.Subscript``) and land here, as do ``ast.Call`` forms like
+    ``sin(b5)`` (GH #428). Lenient predicates that only need a
+    collapse-to-zero verdict (:func:`lhs_collapses_to_zero`) may catch this
+    and treat the expression as still-symbolic; strict evaluators must let
+    it propagate.
+    """
+
+
 def evaluate_at_zero(expr: str, zero_names: set[str] | frozenset[str]) -> float | None:
     """Return ``expr`` evaluated after substituting every name in ``zero_names`` with ``0.0``.
 
@@ -132,15 +146,19 @@ def evaluate_with_substitutions(
 
     Raises
     ------
-    KineticEvalError
-        If ``expr`` contains an AST node kind outside the safe
-        subset (literals, names, unary +/-, binary +/-/*/////**).
+    _UnsupportedNodeError
+        If ``expr`` is not a string, cannot be parsed, or contains an
+        AST node kind outside the safe subset (literals, names, unary
+        +/-, binary +/-/*/////**). Subclass of :class:`KineticEvalError`,
+        so existing broad handlers are unaffected. Genuine evaluation
+        errors (divide-by-zero, ``0 ** negative``) propagate from the
+        recursive evaluator as plain :class:`KineticEvalError`.
     """
     if not isinstance(expr, str):  # type: ignore[reportUnnecessaryIsInstance]
         msg = (
             f"evaluate_with_substitutions: expected a str, got {type(expr).__name__!r}"
         )
-        raise KineticEvalError(msg)
+        raise _UnsupportedNodeError(msg)
     normalized = normalize_inputform(expr)
 
     try:
@@ -150,7 +168,7 @@ def evaluate_with_substitutions(
             f"evaluate_with_substitutions: cannot parse {expr!r} "
             f"(after ^→**: {normalized!r}): {e}"
         )
-        raise KineticEvalError(msg) from e
+        raise _UnsupportedNodeError(msg) from e
 
     try:
         return _eval_node(tree.body, substitutions)
@@ -179,7 +197,7 @@ def _eval_node(node: ast.AST, substitutions: dict[str, float]) -> float:  # noqa
             f"evaluate_with_substitutions: unsupported literal type "
             f"{type(node.value).__name__!r}"
         )
-        raise KineticEvalError(msg)
+        raise _UnsupportedNodeError(msg)
 
     if isinstance(node, ast.Name):
         if node.id in substitutions:
@@ -193,7 +211,7 @@ def _eval_node(node: ast.AST, substitutions: dict[str, float]) -> float:  # noqa
                 f"evaluate_with_substitutions: unsupported unary op "
                 f"{type(node.op).__name__}"
             )
-            raise KineticEvalError(msg)
+            raise _UnsupportedNodeError(msg)
         return op_fn(_eval_node(node.operand, substitutions))
 
     if isinstance(node, ast.BinOp):
@@ -203,7 +221,7 @@ def _eval_node(node: ast.AST, substitutions: dict[str, float]) -> float:  # noqa
                 f"evaluate_with_substitutions: unsupported binary op "
                 f"{type(node.op).__name__}"
             )
-            raise KineticEvalError(msg)
+            raise _UnsupportedNodeError(msg)
         left = _eval_node(node.left, substitutions)
         right = _eval_node(node.right, substitutions)
         # 0**0 is mathematically ambiguous; treat as 1 per IEEE, which is
@@ -221,7 +239,7 @@ def _eval_node(node: ast.AST, substitutions: dict[str, float]) -> float:  # noqa
         return op_fn_bin(left, right)
 
     msg = f"evaluate_with_substitutions: unsupported AST node {type(node).__name__}"
-    raise KineticEvalError(msg)
+    raise _UnsupportedNodeError(msg)
 
 
 def split_small_parameter_kinetic(
@@ -516,9 +534,20 @@ def lhs_collapses_to_zero(
 
     ``None`` kinetic coefficients are implicitly non-perturbative
     (e.g. ``kinetic == 1`` by convention); they never trigger demotion.
+
+    Unsupported-but-parseable constructs (Wolfram call forms such as
+    ``Sin[x[]]``, GH #428) are treated as still-symbolic → non-vanishing →
+    ``False`` (no demotion). This is deliberately conservative: the field
+    stays dynamical and later strict guards classify the kinetic properly
+    (the #421 position-dependence guard, the #290 ``K_eff`` extraction).
+    Genuine evaluation errors (divide-by-zero) still propagate as
+    :class:`KineticEvalError`.
     """
     if kinetic_symbolic is None or not small_parameters:
         return False
     zero_names = frozenset(small_parameters)
-    value = evaluate_at_zero(kinetic_symbolic, zero_names)
+    try:
+        value = evaluate_at_zero(kinetic_symbolic, zero_names)
+    except _UnsupportedNodeError:
+        return False
     return value == 0.0


### PR DESCRIPTION
## Summary

Closes #428.

A Wolfram call-form kinetic like `1 + Sin[x[]]` normalizes to `Sin[x]`
(`ast.Subscript`), which the safe evaluator cannot interpret. The raise
escaped `lhs_collapses_to_zero` and crashed `EquationSystem.base_spec()`
with `KineticEvalError: unsupported AST node` — shadowing the #421
position-dependence guard's actionable message — while the morally
identical power form `1 + x[]^2` sailed through as still-symbolic.

## Changes

- New `_UnsupportedNodeError(KineticEvalError)` marks "cannot interpret"
  raises (non-str input, parse failure, unsupported literal/op/node),
  distinct from genuine evaluation errors (divide-by-zero, `0**negative`),
  which stay plain `KineticEvalError`.
- `lhs_collapses_to_zero` catches only the subclass and returns `False`
  (still-symbolic → non-vanishing → no demotion — conservative; later
  strict guards classify the kinetic properly).
- Every strict caller is behaviorally unchanged: `evaluate_at_zero` /
  `evaluate_at_one`, the #290 `K_eff` extraction
  (`perturbative_driver.py`), the `json_loader` M₀-collapse check, and
  `sign_algebra`'s broad handlers all see the same `KineticEvalError`
  contract (the subclass satisfies it).

## Testing

- New `TestGH428CallFormKinetics` unit tests: call forms → no demotion;
  would-collapse conservatism (`rho*Sin[x[]]` stays dynamical);
  divide-by-zero still propagates; strict evaluator still raises.
- `TestGH421BaseKineticGuard` now parametrizes over `1 + x[]^2` AND
  `1 + Sin[x[]]` — both reach the #421 `NotImplementedError`.
- Full suite + ruff + pyright + cspell clean.
