### PR TITLE
fix(solver): refuse unresolvable kinetic coefficients instead of silent M=1 (#447a)

### DIFF
--- a/tests/test_solver_modal.py
+++ b/tests/test_solver_modal.py
@@ -2191,6 +2191,97 @@ class TestGH421PositionDependentKinetic:
         assert np.all(np.isfinite(result["y"]))
 
 
+class TestGH447KineticEvaluationSwallow:
+    """GH #447(a): `_build_evolution_matrices` no longer swallows kinetic
+    evaluation failures into a silent ``M = 1``.
+
+    The builder caught every exception and continued with M = 1, so a
+    kinetic referencing a parameter absent from ``--param`` produced wrong
+    amplitudes with exit code 0 — including inside the conversion-stability
+    probe, which calls this builder on every gated sweep point and
+    likelihood evaluation. There is no correct fallback: M = 1 is a
+    different theory.
+    """
+
+    def _spec_with_kinetic(self, kinetic: str) -> EquationSystem:
+        spec_data = copy.deepcopy(_KG_1D_SPEC)
+        spec_data["equations"][0]["lhs"]["kinetic_coefficient_symbolic"] = kinetic  # type: ignore[index]
+        # Force the genEig/Schur path: a decoupled algebraic constraint.
+        spec_data["fields"].append({"name": "aux_0", "index": 1})  # type: ignore[union-attr]
+        spec_data["equations"].append(  # type: ignore[union-attr]
+            {
+                "field": "aux_0",
+                "lhs": {"expression": "aux_0", "order": {"time": 0, "space": 0}},
+                "rhs": {
+                    "type": "linear_combination",
+                    "terms": [
+                        {"coefficient": 0.0, "operator": "identity", "field": "phi_0"},
+                    ],
+                },
+            },
+        )
+        return _make_spec(spec_data)
+
+    def _build(self, spec: EquationSystem, params: dict[str, float]) -> None:
+        from tidal.solver.coefficients import CoefficientEvaluator
+        from tidal.solver.modal import (
+            _build_evolution_matrices,
+            _build_k_axes,
+            _build_k_grid,
+        )
+
+        grid = GridInfo(shape=(16,), bounds=((0.0, 10.0),), periodic=(True,))
+        layout = StateLayout.from_spec(spec, grid.num_points)
+        ce = CoefficientEvaluator(spec, grid, params)
+        k_grid = _build_k_grid(_build_k_axes(grid))
+        rfft_shape = (grid.shape[0] // 2 + 1,)
+        _build_evolution_matrices(spec, layout, grid, ce, k_grid, rfft_shape)
+
+    def test_missing_parameter_raises_actionable(self) -> None:
+        from tidal.solver._exceptions import KineticEvaluationError
+
+        spec = self._spec_with_kinetic("-xi")
+        with pytest.raises(KineticEvaluationError) as exc_info:
+            self._build(spec, {"m2": 1.0})  # xi deliberately absent
+        msg = str(exc_info.value)
+        assert "phi_0" in msg  # names the field
+        assert "-xi" in msg  # names the expression
+        assert "xi" in msg
+        assert "--param" in msg
+        assert "m2" in msg  # lists what WAS supplied
+
+    def test_not_swallowed_by_stability_probe(self) -> None:
+        """KineticEvaluationError is a RuntimeError precisely so the probe's
+        ``(LinAlgError, ValueError)`` handler cannot relabel a configuration
+        error as a "tachyonic" physics verdict.
+        """
+        from tidal.measurement._stability import check_conversion_stability
+        from tidal.solver._exceptions import KineticEvaluationError
+
+        spec = self._spec_with_kinetic("-xi")
+        grid = GridInfo(shape=(16,), bounds=((0.0, 10.0),), periodic=(True,))
+        with pytest.raises(KineticEvaluationError):
+            check_conversion_stability(spec, grid, {"m2": 1.0}, source="phi_0")
+
+    def test_resolvable_kinetic_still_builds(self) -> None:
+        """The happy path is unchanged: a kinetic whose symbols are all
+        supplied resolves and populates the mass matrix.
+        """
+        spec = self._spec_with_kinetic("-xi")
+        self._build(spec, {"m2": 1.0, "xi": -2.0})  # no raise
+
+    def test_absent_kinetic_still_defaults_to_one(self) -> None:
+        """``kinetic_coefficient_symbolic: null`` means M = 1 by JSON
+        convention — that is a declared value, not a swallowed failure, and
+        must keep working.
+        """
+        spec_data = copy.deepcopy(_KG_1D_SPEC)
+        spec_data["equations"][0]["lhs"].pop(  # type: ignore[index]
+            "kinetic_coefficient_symbolic", None
+        )
+        self._build(_make_spec(spec_data), {"m2": 1.0})  # no raise
+
+
 class TestGH427PositionDependentKineticModal:
     """GH #427 validation: modal handles position-dependent kinetics via
     real-space M⁻¹(x) folded into the convolution-path coefficients.

--- a/tidal/solver/_exceptions.py
+++ b/tidal/solver/_exceptions.py
@@ -7,3 +7,17 @@ class SimulationDivergedError(RuntimeError):
     This indicates a physical or numerical instability — e.g. a coupled mass
     matrix with a negative eigenvalue causing exponentially growing modes.
     """
+
+
+class KineticEvaluationError(RuntimeError):
+    """Raised when a ``kinetic_coefficient_symbolic`` cannot be resolved to a number.
+
+    The modal builders need a concrete ``M`` to populate the mass matrix.
+    When evaluation fails — an unbound symbol (a parameter missing from
+    ``--param``), an unsupported construct, or a NaN/Inf result — there is
+    no correct fallback: proceeding with ``M = 1`` silently changes the
+    physics (GH #447). Raised instead of a bare ``ValueError`` on purpose:
+    the conversion-stability probe catches ``(LinAlgError, ValueError)``
+    and converts it into a "tachyonic" verdict, which would mislabel a
+    configuration error as a physics result.
+    """

--- a/tidal/solver/modal.py
+++ b/tidal/solver/modal.py
@@ -136,6 +136,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from tidal.solver._defaults import DEFAULT_ATOL, DEFAULT_RTOL
+from tidal.solver._exceptions import KineticEvaluationError
 from tidal.solver._setup import warn_frozen_constraints
 from tidal.solver.operators import get_wavenumbers, is_periodic_bc
 from tidal.solver.state import StateLayout
@@ -417,6 +418,42 @@ def can_use_modal(
     # builders, which fold M⁻¹(x) into the real-space coefficients. The
     # former requirement 6 (GH #421 refusal) is retired.
     return True
+
+
+def _kinetic_eval_error(
+    field_name: str,
+    kin_sym: str,
+    coeff_eval: object,
+    exc: Exception,
+) -> KineticEvaluationError:
+    """Build the GH #447 refusal for an unresolvable kinetic coefficient.
+
+    Names the field and the expression, and — for the common case of an
+    unbound symbol — the missing name and the parameters that WERE
+    supplied, since "forgot a ``--param``" is the failure this most often
+    represents. ``evaluate_coefficient`` wraps the original exception, so
+    the unbound-name case is recovered from the ``__cause__`` chain.
+    """
+    cause: BaseException | None = exc
+    while cause is not None and not isinstance(cause, NameError):
+        cause = cause.__cause__
+    hint = ""
+    if isinstance(cause, NameError):
+        params = getattr(coeff_eval, "_parameters", {}) or {}
+        supplied = ", ".join(sorted(params)) or "(none)"
+        hint = (
+            f" The expression references a symbol that has no value: "
+            f"{cause}. Parameters supplied: {supplied}. Pass the missing "
+            f"one with --param NAME=VALUE (or add it to the theory's "
+            f"[parameters] section)."
+        )
+    msg = (
+        f"Cannot evaluate the kinetic coefficient for field {field_name!r} "
+        f"(expression: {kin_sym!r}): {exc}.{hint} The modal mass matrix "
+        f"needs a concrete M; continuing with M = 1 would silently solve a "
+        f"different theory, so this is refused (GH #447)."
+    )
+    return KineticEvaluationError(msg)
 
 
 def _raise_position_dependent_kinetic(spec: EquationSystem, where: str) -> None:
@@ -902,26 +939,45 @@ def _build_evolution_matrices(
         eq_f = eq_for_field[fname]
         kin_sym = getattr(eq_f, "kinetic_coefficient_symbolic", None)
         if kin_sym is None:
+            # No kinetic declared — M = 1 by JSON convention (not a fallback).
             M_mat[:, fi, fi] = 1.0
         else:
+            # GH #447: no silent fallback. This builder previously caught
+            # every exception and proceeded with M = 1, so a kinetic
+            # referencing a parameter absent from `--param` produced wrong
+            # amplitudes with exit code 0 — and did so inside the stability
+            # probe that gates every sweep point / likelihood evaluation.
+            # There is no correct fallback value: M = 1 is a different
+            # theory. Raise KineticEvaluationError (a RuntimeError, so the
+            # probe's (LinAlgError, ValueError) handler cannot relabel it
+            # "tachyonic") with the field, the expression and the cause.
             try:
                 kin_val = evaluate_coefficient(
                     kin_sym,
                     coeff_eval._parameters,  # noqa: SLF001  # type: ignore[reportPrivateUsage]
                     spec.effective_coordinates,
                 )
-            except Exception:  # noqa: BLE001
-                # Fall back to the old hardcoded value if resolution fails.
-                # Matches the behavior of normalize_kinetic_coefficients
-                # which skips normalization in this case.
-                M_mat[:, fi, fi] = 1.0
-                continue
+            except (ValueError, TypeError, ArithmeticError) as exc:
+                raise _kinetic_eval_error(fname, kin_sym, coeff_eval, exc) from exc
             if isinstance(kin_val, np.ndarray):
-                # Position-dependent kinetic — broadcast to per-mode shape.
-                # (Rare; most theories have constant kin coefficients.)
-                M_mat[:, fi, fi] = complex(kin_val.ravel()[0])
-            else:
-                M_mat[:, fi, fi] = complex(float(kin_val))
+                # Position-dependent kinetics are refused by the guard at
+                # the top of this function, so an array here means the
+                # coefficient varies over some other axis (e.g. time) that
+                # the per-mode mass matrix cannot represent either.
+                # Collapsing to element 0 would silently pick one point
+                # (the GH #438 defect class).
+                msg = (
+                    f"Kinetic coefficient for field {fname!r} evaluated to an "
+                    f"array rather than a scalar (expression: {kin_sym!r}). "
+                    f"The generalized-eigenvalue builder writes M onto a "
+                    f"per-mode mass matrix and has no representation for a "
+                    f"varying M. Use plain solve_modal / auto-selection "
+                    f"(position-dependent kinetics run on the convolution "
+                    f"paths, GH #427) or a time-domain scheme "
+                    f"(--scheme cvode / --scheme ida)."
+                )
+                raise KineticEvaluationError(msg)
+            M_mat[:, fi, fi] = complex(float(kin_val))
 
     # Constraint matrices — built in two phases:
     #   Phase 1: collect terms from constraint equations


### PR DESCRIPTION
## Summary

Addresses item **(a)** of #447 — the last live item in that issue (see the
[status comment](https://github.com/WilliamRoyce/tidal/issues/447#issuecomment-5344775402):
(b) is fixed in 3f55223c, (c) and (d) became moot with #427, (e) is a note).

`_build_evolution_matrices` caught **every** exception from kinetic-coefficient
evaluation and continued with `M = 1`. A kinetic referencing a parameter absent
from `--param` therefore produced wrong amplitudes with exit code 0 — and did so
inside the conversion-stability probe, which calls this builder on every gated
sweep point and likelihood evaluation. There is no correct fallback value here:
`M = 1` is a different theory.

## Changes

- New `KineticEvaluationError` in `tidal/solver/_exceptions.py`. Deliberately a
  `RuntimeError`, **not** a `ValueError`: the stability probe catches
  `(LinAlgError, ValueError)` and converts it into a "tachyonic" verdict, which
  would relabel a configuration error as a physics result. Same design intent as
  the #421/#438 guards.
- `_build_evolution_matrices` raises instead of swallowing. The message names the
  field, the expression, the underlying cause and — for the common unbound-symbol
  case, recovered from the `__cause__` chain — the missing name plus the
  parameters that *were* supplied, so the fix (`--param NAME=VALUE`) is obvious.
- The `complex(kin_val.ravel()[0])` corner-collapse in the same block now raises
  too (the #438 defect class). Unreachable for position-dependent kinetics thanks
  to the guard at the top of the function, but it would have silently picked grid
  point 0 for any other varying `M`.
- `kinetic_coefficient_symbolic: null` → `M = 1` is untouched: that is a declared
  value by JSON convention, not a swallowed failure.

## Testing

`TestGH447KineticEvaluationSwallow` (4 tests): missing parameter raises with an
actionable message; the probe does **not** swallow it into a tachyonic verdict;
the happy path with all symbols supplied still builds; absent-kinetic still
defaults to `M = 1`.

Corpus check: no shipped spec has a time-dependent kinetic (the other class that
reached the swallow), and the pre-change suite passed with the fallback removed
locally — nothing depended on it. Full suite + ruff + pyright + cspell clean.

## Blast radius (accepted deliberately)

Runs that previously completed silently with `M = 1` now fail loudly. That is the
point: those runs were solving a different theory. Verified that the shipped
`gertsenshtein.json` behaves identically before and after this change (it already
required `--param kappa=` via a different, already-loud path).



Closes #386 (pre-existing duplicate of #447(a) — same silent M=1 swallow, filed 2026-08-18 during the #382 work).
