### PR TITLE
Prior support has one source of truth; close the last silent paths from the #420 family

### DIFF
--- a/.claude/rules/inference.md
+++ b/.claude/rules/inference.md
@@ -16,6 +16,13 @@ paths:
 2. **arctan_uniform's recorded low/high are UNUSED** (#425): the support is fixed at
    ±tan(π/2 − `_ARCTAN_EPS`) ≈ ±19.98. Never derive a histogram range, support, or
    density from those recorded bounds. `0:0` is the sanctioned "unused" sentinel.
+   Ask `tidal.inference._prior.effective_support(dist, low, high)` — the ONE place
+   that answers "what range was sampled". Every module that answered it privately
+   was wrong: the #420 estimator read the bounds as a histogram range, and the
+   corner plot read them as degrees and drew ±57.3 panels (#451). New chains also
+   record `effective_low`/`effective_high` per scalar prior (omitted when
+   unbounded, since `Infinity` is not valid strict JSON); archived chains have
+   the support reconstructed on read, never by trusting `low`/`high`.
 3. **Never rank a marginal at or below its noise floor** `(n_bins − 1)/(2·n_eff)`
    (#433). Every consumer of `marginal_d_kl` (tables, plots, TeX emitters) must
    consult `consistency["floor_dominated_params"]` / `noise_floor` before ranking

--- a/docs/V3_ARCHITECTURE.md
+++ b/docs/V3_ARCHITECTURE.md
@@ -18,6 +18,12 @@ This document is the canonical architecture reference for the v3 era. It survive
 > compactified-prior table below misstates the `arctan_uniform` support: the
 > bounds `-89:89` are **ignored by the sampler** (GH #425) and the support is
 > fixed at ±tan(π/2 − 0.05) ≈ **±19.98**, not "degrees → tan(±89°) ≈ ±57".
+> The corner plot implemented that same ±57.3 misreading until v0.49.2, drawing
+> `--full-prior-bounds` panels ~2.9× wider than the sampled range (GH #451, fixed);
+> no committed figure script or campaign template passes that flag, so no recorded
+> figure is affected. Since v0.49.2 the support has a single source of truth,
+> `tidal.inference._prior.effective_support`, and new chains record
+> `effective_low`/`effective_high` per prior.
 > Post-v0.48.8, `importance.json` carries a `consistency` block (N_eff, noise
 > floors, superadditivity); marginals below their floor must not be ranked
 > (GH #433).

--- a/docs/tex/inference.tex
+++ b/docs/tex/inference.tex
@@ -74,6 +74,24 @@ unused.  (Campaign metadata that records \texttt{arctan\_uniform:-89:89}
 describes bounds that were never sampled --- this mismatch was one of the
 two mechanisms behind the GH \#420 marginal-$D_\mathrm{KL}$ inflation.)
 
+\paragraph{Effective support --- one source of truth}
+Because the recorded bounds can describe nothing, no consumer may re-derive
+a prior's range from them.  \texttt{tidal.inference.\_prior.effective\_support(%
+distribution, low, high)} is the single accessor for \emph{the range that was
+actually sampled}: the recorded bounds for uniform and log-uniform, the fixed
+$\pm 19.98$ for arctan-uniform, and $(-\infty, +\infty)$ for normal (whose
+support is genuinely unbounded --- callers needing a finite plotting range
+derive one themselves rather than being handed a silent truncation).  Every
+module that answered this question privately answered it wrongly: the
+marginal-$D_\mathrm{KL}$ estimator histogrammed a $\pm 20$ posterior over
+$(-89, 89)$ (GH \#420) and the \texttt{--full-prior-bounds} corner plot read
+the bounds as \emph{degrees} and drew $\pm\tan(89^\circ) \approx \pm 57.3$
+panels (GH \#451).  Chains written from v0.49.2 also record
+\texttt{effective\_low}/\texttt{effective\_high} in each scalar prior record
+(omitted when the support is unbounded, since \texttt{Infinity} is not valid
+strict JSON); archived chains, which record only the requested bounds, have
+their support reconstructed on read.
+
 Each prior implements three operations required by the sampling pipeline:
 \texttt{sample(rng, n)} for Monte Carlo, \texttt{log\_prob(x)} for posterior
 weighting, and \texttt{transform(u)} for nested sampling's unit-cube protocol.

--- a/scripts/figures/kl_carrier_corner.py
+++ b/scripts/figures/kl_carrier_corner.py
@@ -102,17 +102,41 @@ def _label(name: str) -> str:
 
 
 def _pick_top_k(importance: dict, k: int) -> list[str]:
-    """Rank parameters by combined max(amp marginal, sup marginal, cross)."""
+    """Rank parameters by combined max(amp marginal, sup marginal, cross).
+
+    Floor-dominated marginals are dropped from the score (GH #433): on a
+    low-N_eff chain they are estimator bias of up to ~0.9 nats, which
+    would out-rank a legitimate cross-KL and pick the figure's "carrier"
+    coupling by noise.  The cross-KL term is prior-free and keeps its
+    vote, so a parameter with real amp-vs-sup structure still ranks even
+    when both its marginals are floor.
+    """
+    from tidal.inference._importance import floor_dominated_params
+
     amp = importance.get("amp", {}).get("marginal_d_kl", {}) or {}
     sup = importance.get("sup", {}).get("marginal_d_kl", {}) or {}
     cross = importance.get("cross_amp_sup_kl", {}) or {}
+    amp_floor = floor_dominated_params(importance.get("amp", {}))
+    sup_floor = floor_dominated_params(importance.get("sup", {}))
+    if amp_floor or sup_floor:
+        log.warning(
+            "floor-dominated marginals excluded from ranking — amp: %s; sup: %s",
+            sorted(amp_floor) or "none",
+            sorted(sup_floor) or "none",
+        )
     names = list(amp.keys() or sup.keys() or cross.keys())
+
+    def _val(d: dict, name: str, excluded: frozenset[str]) -> float:
+        if name in excluded:
+            return 0.0
+        v = d.get(name, 0.0)
+        return v if v is not None and math.isfinite(v) else 0.0
 
     def score(name: str) -> float:
         return max(
-            amp.get(name, 0.0) if math.isfinite(amp.get(name, 0.0) or 0.0) else 0.0,
-            sup.get(name, 0.0) if math.isfinite(sup.get(name, 0.0) or 0.0) else 0.0,
-            cross.get(name, 0.0) if math.isfinite(cross.get(name, 0.0) or 0.0) else 0.0,
+            _val(amp, name, amp_floor),
+            _val(sup, name, sup_floor),
+            _val(cross, name, frozenset()),
         )
 
     return sorted(names, key=lambda n: -score(n))[:k]

--- a/scripts/figures/overlay_corner_pair.py
+++ b/scripts/figures/overlay_corner_pair.py
@@ -85,10 +85,28 @@ def _label(name: str) -> str:
 
 
 def _score_from_imp(imp: dict, name: str) -> float:
+    """Combined max(amp marginal, sup marginal, cross) for one parameter.
+
+    A marginal flagged floor-dominated contributes 0 (GH #433): at low
+    N_eff it is estimator bias, and ranking on it selects the figure's
+    parameters by noise.  Cross-KL is prior-free and always counts.
+    """
+    from tidal.inference._importance import floor_dominated_params
+
     amp = imp.get("amp", {}).get("marginal_d_kl", {}) or {}
     sup = imp.get("sup", {}).get("marginal_d_kl", {}) or {}
     cross = imp.get("cross_amp_sup_kl", {}) or {}
-    vals = [amp.get(name, 0.0), sup.get(name, 0.0), cross.get(name, 0.0)]
+    amp_val = (
+        0.0
+        if name in floor_dominated_params(imp.get("amp", {}))
+        else amp.get(name, 0.0)
+    )
+    sup_val = (
+        0.0
+        if name in floor_dominated_params(imp.get("sup", {}))
+        else sup.get(name, 0.0)
+    )
+    vals = [amp_val, sup_val, cross.get(name, 0.0)]
     vals = [v if v is not None and math.isfinite(v) else 0.0 for v in vals]
     return max(vals)
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -1946,6 +1947,320 @@ class TestMarginalDKLPriorTransforms:
         imp = compute_parameter_importance(result, n_bootstrap=10)
         assert imp.consistency["floor_dominated_params"] == []
         assert "(<= floor)" not in format_importance_table(imp)
+
+
+class TestEffectivePriorSupport:
+    """GH #451/#425: one source of truth for the range a prior samples.
+
+    Consumers must never re-derive the support from the recorded
+    ``low``/``high`` — ``arctan_uniform`` ignores them, and every
+    independent re-derivation of that fact so far has been wrong (the
+    #420 estimator read them as a histogram range; the corner plot read
+    them as degrees).
+    """
+
+    def test_arctan_support_is_the_sampled_range_not_the_bounds(self) -> None:
+        from tidal.inference._prior import _ARCTAN_EPS, effective_support
+
+        lo, hi = effective_support("arctan_uniform", -89.0, 89.0)
+        expected = math.tan(math.pi / 2 - _ARCTAN_EPS)
+        assert lo == pytest.approx(-expected)
+        assert hi == pytest.approx(expected)
+        # The two wrong answers this replaced.
+        assert hi == pytest.approx(19.98, abs=0.01)
+        assert hi != pytest.approx(89.0)
+        assert hi != pytest.approx(math.tan(math.radians(89.0)), abs=1.0)
+
+    def test_arctan_support_matches_what_sample_actually_draws(self) -> None:
+        """The contract is empirical: draws must lie inside the support."""
+        from tidal.inference._prior import Prior
+
+        with pytest.warns(UserWarning, match="ignores its bounds"):
+            prior = Prior(name="a", distribution="arctan_uniform", low=-89.0, high=89.0)
+        lo, hi = prior.effective_support
+        draws = prior.sample(np.random.default_rng(0), 20000)
+        assert draws.min() >= lo
+        assert draws.max() <= hi
+        # And the support is tight, not a loose envelope.
+        assert draws.max() > 0.9 * hi
+
+    def test_bounded_kinds_report_their_bounds(self) -> None:
+        from tidal.inference._prior import effective_support
+
+        assert effective_support("uniform", -2.0, 3.0) == (-2.0, 3.0)
+        assert effective_support("log_uniform", 1e-3, 1e3) == (1e-3, 1e3)
+
+    def test_normal_support_is_infinite_not_silently_truncated(self) -> None:
+        from tidal.inference._prior import effective_support
+
+        lo, hi = effective_support("normal", 0.0, 1.0)
+        assert lo == -math.inf
+        assert hi == math.inf
+
+    def test_unknown_kind_raises(self) -> None:
+        from tidal.inference._prior import effective_support
+
+        with pytest.raises(ValueError, match="Unknown distribution"):
+            effective_support("cauchy", 0.0, 1.0)
+
+    def test_every_valid_kind_has_a_support(self) -> None:
+        """Adding a kind without teaching effective_support fails here."""
+        from tidal.inference._prior import VALID_DISTRIBUTIONS, effective_support
+
+        for kind in VALID_DISTRIBUTIONS:
+            lo, hi = effective_support(kind, 0.5, 2.0)
+            assert lo < hi
+
+
+class TestPriorMapUsesEffectiveSupport:
+    """The corner-plot prior map must report sampled ranges (GH #451)."""
+
+    @staticmethod
+    def _result(priors: list[dict[str, object]]) -> object:
+        from tidal.inference._results import InferenceResult
+
+        n = 32
+        return InferenceResult(
+            samples=np.zeros((n, 1)),
+            log_likelihood=np.zeros(n),
+            log_prior=np.zeros(n),
+            param_names=["a"],
+            method="nested",
+            log_evidence=0.0,
+            log_evidence_err=0.1,
+            weights=np.ones(n) / n,
+            metadata={"priors": priors},
+        )
+
+    def test_archived_record_without_effective_keys_is_corrected_on_read(
+        self,
+    ) -> None:
+        """Old chains record only the unused bounds; do not trust them."""
+        from tidal.inference._visualize import (
+            _extract_prior_map,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        result = self._result(
+            [
+                {
+                    "kind": "scalar",
+                    "name": "a",
+                    "distribution": "arctan_uniform",
+                    "low": -89.0,
+                    "high": 89.0,
+                }
+            ]
+        )
+        dist, _lo, hi = _extract_prior_map(result)["a"]
+        assert dist == "arctan_uniform"
+        assert hi == pytest.approx(19.98, abs=0.01)
+        # Neither the recorded bound nor the degrees misreading.
+        assert hi != pytest.approx(89.0)
+        assert hi < 30.0
+
+    def test_recorded_effective_keys_are_used_verbatim(self) -> None:
+        from tidal.inference._visualize import (
+            _extract_prior_map,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        result = self._result(
+            [
+                {
+                    "kind": "scalar",
+                    "name": "a",
+                    "distribution": "arctan_uniform",
+                    "low": -89.0,
+                    "high": 89.0,
+                    "effective_low": -19.98,
+                    "effective_high": 19.98,
+                }
+            ]
+        )
+        _dist, lo, hi = _extract_prior_map(result)["a"]
+        assert (lo, hi) == (-19.98, 19.98)
+
+    def test_unbounded_support_is_omitted_not_truncated(self) -> None:
+        from tidal.inference._visualize import (
+            _extract_prior_map,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        result = self._result(
+            [
+                {
+                    "kind": "scalar",
+                    "name": "a",
+                    "distribution": "normal",
+                    "low": 0.0,
+                    "high": 1.0,
+                }
+            ]
+        )
+        assert "a" not in _extract_prior_map(result)
+
+    def test_full_prior_axis_limits_use_the_sampled_range(self) -> None:
+        """The GH #451 defect itself: panels drawn to +-57.3, not +-19.98."""
+        matplotlib = pytest.importorskip("matplotlib")
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        from tidal.inference._visualize import (
+            _set_full_prior_axis_limits,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        fig, ax = plt.subplots()
+        axes = np.array([[ax]], dtype=object)
+        _set_full_prior_axis_limits(
+            axes, ["a"], {"a": ("arctan_uniform", -19.98, 19.98)}
+        )
+        _lo, hi = ax.get_xlim()
+        plt.close(fig)
+        assert hi == pytest.approx(19.98, abs=0.01)
+        assert hi < 30.0, "regressed to the tan(degrees) misreading"
+
+    def test_arctan_prior_overlay_is_drawn(self) -> None:
+        """#309's null check was unavailable for arctan params."""
+        matplotlib = pytest.importorskip("matplotlib")
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        from tidal.inference._visualize import (
+            _overlay_priors,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        result = self._result(
+            [
+                {
+                    "kind": "scalar",
+                    "name": "a",
+                    "distribution": "arctan_uniform",
+                    "low": -89.0,
+                    "high": 89.0,
+                }
+            ]
+        )
+        fig, ax = plt.subplots()
+        axes = np.array([[ax]], dtype=object)
+        _overlay_priors(axes, result)
+        lines = [ln for ln in ax.get_lines() if ln.get_label() == "prior"]
+        assert len(lines) == 1, "no prior density drawn for arctan_uniform"
+        xs = np.asarray(lines[0].get_xdata(), dtype=float)
+        ys = np.asarray(lines[0].get_ydata(), dtype=float)
+        # Cauchy shape: peaked at 0, decaying by 1/(1+x^2).
+        peak = float(np.max(ys))
+        assert float(ys[int(np.argmin(np.abs(xs)))]) == pytest.approx(peak, rel=1e-6)
+        assert float(ys[0]) < 0.01 * peak
+        plt.close(fig)
+
+
+class TestFloorDominatedAccessor:
+    """GH #433: every ranking consumer asks the same question one way."""
+
+    def test_reads_the_consistency_block(self) -> None:
+        from tidal.inference._importance import floor_dominated_params
+
+        block = {
+            "marginal_d_kl": {"a": 0.9, "b": 0.1},
+            "consistency": {"floor_dominated_params": ["a"]},
+        }
+        assert floor_dominated_params(block) == frozenset({"a"})
+
+    def test_pre_consistency_block_returns_empty(self) -> None:
+        """A pre-v0.48.8 block has no floors computed — not 'no floors'."""
+        from tidal.inference._importance import floor_dominated_params
+
+        assert floor_dominated_params({"marginal_d_kl": {"a": 0.9}}) == frozenset()
+
+    def test_malformed_consistency_does_not_raise(self) -> None:
+        from tidal.inference._importance import floor_dominated_params
+
+        assert floor_dominated_params({"consistency": "nonsense"}) == frozenset()
+        assert (
+            floor_dominated_params({"consistency": {"floor_dominated_params": None}})
+            == frozenset()
+        )
+
+    def test_figure_ranking_drops_floor_marginals_but_keeps_cross(self) -> None:
+        """The kl_carrier_corner selection must not rank on estimator noise."""
+        import importlib.util
+        import sys
+
+        path = (
+            Path(__file__).resolve().parents[1]
+            / "scripts"
+            / "figures"
+            / "kl_carrier_corner.py"
+        )
+        spec = importlib.util.spec_from_file_location("_kl_carrier_corner", path)
+        assert spec is not None
+        assert spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        try:
+            spec.loader.exec_module(mod)
+        finally:
+            sys.modules.pop(spec.name, None)
+
+        importance = {
+            "amp": {
+                "marginal_d_kl": {"noise": 0.90, "real": 0.05},
+                "consistency": {"floor_dominated_params": ["noise", "real"]},
+            },
+            "sup": {
+                "marginal_d_kl": {"noise": 0.88, "real": 0.04},
+                "consistency": {"floor_dominated_params": ["noise", "real"]},
+            },
+            # Prior-free, unaffected by #420/#433 — this is the real signal.
+            "cross_amp_sup_kl": {"noise": 0.01, "real": 3.2},
+        }
+        assert mod._pick_top_k(importance, 1) == ["real"]
+
+
+class TestNestedSaveWithoutPriorsWarns:
+    """GH #434: a nested chain saved with no priors block must say so."""
+
+    @staticmethod
+    def _result(metadata: dict[str, object]) -> object:
+        from tidal.inference._results import InferenceResult
+
+        n = 40
+        rng = np.random.default_rng(3)
+        return InferenceResult(
+            samples=rng.uniform(-1, 1, (n, 1)),
+            log_likelihood=np.zeros(n),
+            log_prior=np.zeros(n),
+            param_names=["a"],
+            method="nested",
+            log_evidence=0.0,
+            log_evidence_err=0.1,
+            weights=np.ones(n) / n,
+            metadata=metadata,
+        )
+
+    def test_missing_priors_warns_and_names_the_consequence(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        result = self._result({"sampler": "test", "nlive": 10})
+        with caplog.at_level(logging.WARNING, logger="tidal.inference"):
+            result.save(tmp_path)  # pyright: ignore[reportAttributeAccessIssue]
+        assert "no priors metadata" in caplog.text
+        assert "#434" in caplog.text
+
+    def test_recorded_priors_do_not_warn(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from tidal.inference._prior import Prior
+
+        prior = Prior(name="a", distribution="uniform", low=-1.0, high=1.0)
+        result = self._result(
+            {"sampler": "test", "nlive": 10, "priors": [prior]},
+        )
+        with caplog.at_level(logging.WARNING, logger="tidal.inference"):
+            result.save(tmp_path)  # pyright: ignore[reportAttributeAccessIssue]
+        assert "no priors metadata" not in caplog.text
 
 
 # ===================================================================

--- a/tidal/cli/_sample.py
+++ b/tidal/cli/_sample.py
@@ -354,34 +354,9 @@ def sample_command(args: Namespace) -> int:  # noqa: C901, PLR0911, PLR0912, PLR
         # marginal D_KL per parameter, #308) can transform each column
         # into the space where its prior is uniform.  Mixed priors are
         # serialized by type so the loader can reconstruct each component.
-        import numpy as np
+        from tidal.inference._prior import to_record
 
-        prior_records: list[dict[str, object]] = []
-        for p in priors:
-            if isinstance(p, RadialAngularPrior):
-                prior_records.append(
-                    {
-                        "kind": "radial_angular",
-                        "names": list(p.names),
-                        "r_lo": p.r_lo,
-                        "r_hi": p.r_hi,
-                        "face_idx": p.face_idx,
-                        "sub_tile": list(p.sub_tile),
-                        "M": p.M,
-                        "Q": np.asarray(p.Q).tolist(),
-                    }
-                )
-            else:
-                prior_records.append(
-                    {
-                        "kind": "scalar",
-                        "name": p.name,
-                        "distribution": p.distribution,
-                        "low": p.low,
-                        "high": p.high,
-                    }
-                )
-        result.metadata["priors"] = prior_records
+        result.metadata["priors"] = [to_record(p) for p in priors]
         # Persist likelihood mode so the corner-plot title can label the
         # extremal logL correctly: "max A" for maximize, "max suppression"
         # for minimize, etc.  Without this the same number means different

--- a/tidal/inference/_importance.py
+++ b/tidal/inference/_importance.py
@@ -16,6 +16,7 @@ Handley, W. et al. (2015) "PolyChord: next-generation nested sampling",
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -865,6 +866,31 @@ def compute_cross_kl(
             cross[name] = float("nan")
 
     return cross
+
+
+def floor_dominated_params(importance_block: Mapping[str, Any]) -> frozenset[str]:
+    """Names in a saved importance block whose marginal is estimator noise.
+
+    Reads ``consistency.floor_dominated_params`` from one direction's
+    block of a ``parameter_importance.json`` / ``importance.json`` (the
+    dict holding ``marginal_d_kl``).  Provided so every consumer that
+    RANKS marginals — tables, TeX emitters, figure-selection scripts —
+    asks the same question the same way instead of each deciding for
+    itself whether a 0.9-nat marginal from an N_eff = 21 chain is signal
+    (GH #433).
+
+    Returns an empty set for a pre-v0.48.8 block with no consistency
+    data: absence of the block means the floors were never computed, not
+    that nothing is floor-dominated, so callers that care about the
+    difference should check for the key themselves.
+    """
+    consistency = importance_block.get("consistency")
+    if not isinstance(consistency, Mapping):
+        return frozenset()
+    names = consistency.get("floor_dominated_params")
+    if not isinstance(names, (list, tuple, set, frozenset)):
+        return frozenset()
+    return frozenset(str(n) for n in names)
 
 
 def format_importance_table(result: ParameterImportanceResult) -> str:

--- a/tidal/inference/_prior.py
+++ b/tidal/inference/_prior.py
@@ -37,6 +37,56 @@ _ARCTAN_EPS = 0.05
 VALID_DISTRIBUTIONS = frozenset({"uniform", "log_uniform", "normal", "arctan_uniform"})
 
 
+def effective_support(
+    distribution: str, low: float, high: float
+) -> tuple[float, float]:
+    """The range a prior actually samples from — not the range that was typed.
+
+    The single source of truth for "what range was sampled", so no
+    consumer has to re-derive it from the recorded ``low``/``high``.
+    Every place that did so independently got it wrong at least once:
+    the marginal D_KL estimator histogrammed a +-20 posterior over
+    ``(-89, 89)`` (GH #420) and the ``--full-prior-bounds`` corner plot
+    drew ``arctan_uniform`` panels over ``tan(radians(+-89))`` = +-57.3
+    (GH #451), because both read bounds that ``arctan_uniform`` ignores
+    (GH #425).
+
+    Exposed as a free function as well as :attr:`Prior.effective_support`
+    so consumers reading archived prior *records* can ask without
+    constructing a :class:`Prior` (which would re-emit the GH #425
+    bounds-ignored warning on every replot of an archived chain).
+
+    Returns
+    -------
+    tuple[float, float]
+        ``(low, high)`` for ``uniform``/``log_uniform`` (the recorded
+        bounds ARE the support); ``(-S, +S)`` with
+        ``S = tan(pi/2 - _ARCTAN_EPS) ~= 19.98`` for ``arctan_uniform``,
+        independent of the recorded bounds; ``(-inf, +inf)`` for
+        ``normal``, whose support is genuinely unbounded — callers
+        needing a finite plotting range must derive one from the mean
+        and std themselves rather than be handed a silently truncated
+        interval.
+
+    Raises
+    ------
+    ValueError
+        If ``distribution`` is not in :data:`VALID_DISTRIBUTIONS`.
+    """
+    if distribution not in VALID_DISTRIBUTIONS:
+        msg = (
+            f"Unknown distribution '{distribution}'. Must be one of "
+            f"{sorted(VALID_DISTRIBUTIONS)}."
+        )
+        raise ValueError(msg)
+    if distribution == "arctan_uniform":
+        support = math.tan(math.pi / 2 - _ARCTAN_EPS)
+        return (-support, support)
+    if distribution == "normal":
+        return (-math.inf, math.inf)
+    return (float(low), float(high))
+
+
 @dataclass(frozen=True)
 class Prior:
     """A 1-D marginal prior distribution.
@@ -120,6 +170,19 @@ class Prior:
                     UserWarning,
                     stacklevel=3,
                 )
+
+    # ------------------------------------------------------------------
+    # Support
+    # ------------------------------------------------------------------
+
+    @property
+    def effective_support(self) -> tuple[float, float]:
+        """The range :meth:`sample` actually draws from — not what was typed.
+
+        Thin accessor for :func:`effective_support`; see it for the
+        per-distribution contract and the defects that motivated it.
+        """
+        return effective_support(self.distribution, self.low, self.high)
 
     # ------------------------------------------------------------------
     # Sampling (Monte Carlo)
@@ -436,6 +499,48 @@ def parse_joint_prior(spec: str) -> RadialAngularPrior:
 def total_prior_ndim(priors: list[Prior | RadialAngularPrior]) -> int:
     """Total cube dimension covered by a (possibly mixed) prior list."""
     return sum(p.n_dims if isinstance(p, RadialAngularPrior) else 1 for p in priors)
+
+
+def to_record(prior: Prior | RadialAngularPrior) -> dict[str, object]:
+    """Serialize a prior to its on-disk record (``inference.json`` ``priors``).
+
+    One definition of the record shape, shared by the writer in
+    :mod:`tidal.cli._sample` and by :meth:`InferenceResult.save`, so a
+    result whose ``metadata["priors"]`` holds live prior objects — which
+    the importance estimator accepts — reaches disk in the same form as
+    one built by the CLI, instead of raising "not JSON serializable"
+    there.  Every recorded chain having a faithful priors block is what
+    GH #434 was about.
+
+    Scalar records carry ``effective_low``/``effective_high`` alongside
+    the requested ``low``/``high`` so post-hoc consumers read what was
+    sampled rather than re-deriving it (GH #425/#451).  The keys are
+    OMITTED for an unbounded support, since ``Infinity`` is not valid
+    strict JSON.
+    """
+    if isinstance(prior, RadialAngularPrior):
+        return {
+            "kind": "radial_angular",
+            "names": list(prior.names),
+            "r_lo": prior.r_lo,
+            "r_hi": prior.r_hi,
+            "face_idx": prior.face_idx,
+            "sub_tile": list(prior.sub_tile),
+            "M": prior.M,
+            "Q": np.asarray(prior.Q).tolist(),
+        }
+    record: dict[str, object] = {
+        "kind": "scalar",
+        "name": prior.name,
+        "distribution": prior.distribution,
+        "low": prior.low,
+        "high": prior.high,
+    }
+    eff_lo, eff_hi = prior.effective_support
+    if math.isfinite(eff_lo) and math.isfinite(eff_hi):
+        record["effective_low"] = eff_lo
+        record["effective_high"] = eff_hi
+    return record
 
 
 def prior_param_names(priors: list[Prior | RadialAngularPrior]) -> list[str]:

--- a/tidal/inference/_results.py
+++ b/tidal/inference/_results.py
@@ -414,7 +414,43 @@ class InferenceResult:
             summary["sampler"] = sampler
         priors = self.metadata.get("priors")
         if priors is not None:
-            summary["priors"] = priors
+            # Normalize live prior objects to records. compute_parameter_
+            # importance accepts either form, so a result assembled in
+            # memory can carry Prior instances; without this they reach
+            # json.dump and raise "not JSON serializable" at the very
+            # last step of a finished run.
+            from tidal.inference._prior import (
+                Prior,
+                RadialAngularPrior,
+                to_record,
+            )
+
+            if isinstance(priors, list):
+                summary["priors"] = [
+                    to_record(p) if isinstance(p, (Prior, RadialAngularPrior)) else p
+                    for p in priors
+                ]
+            else:
+                summary["priors"] = priors
+        elif self.method == "nested":
+            # GH #434: six pre-schema campaign chains saved without a
+            # priors block, and the post-hoc recompute had to FABRICATE
+            # an all-arctan prior set for them — which was wrong for the
+            # runs that used a log-uniform xi, giving a spurious dominant
+            # 1.66 nats. The omission was silent then; it must not be.
+            # Warn rather than raise: a result assembled programmatically
+            # (tests, ad-hoc analysis) is entitled to have no priors, it
+            # just cannot be scored against them later.
+            import logging
+
+            logging.getLogger("tidal.inference").warning(
+                "saving nested result to %s with no priors metadata — "
+                "per-parameter marginal D_KL cannot be computed from this "
+                "directory, and post-hoc analysis will have to reconstruct "
+                "the priors from run provenance (see GH #434). Set "
+                "result.metadata['priors'] before saving.",
+                output_dir,
+            )
         rejected_prior_path = self.metadata.get("rejected_prior_path")
         if rejected_prior_path is not None:
             summary["rejected_prior_path"] = str(rejected_prior_path)

--- a/tidal/inference/_visualize.py
+++ b/tidal/inference/_visualize.py
@@ -683,29 +683,25 @@ def _set_full_prior_axis_limits(
     Counter-part to :func:`_set_derived_axis_limits` which uses the
     posterior-weighted 5%-95% interval.  This mode is invoked by
     ``tidal plot --type corner --full-prior-bounds`` to make the
-    compactified-prior coverage visually honest: arctan_uniform:-89:89
-    panels show their full ±tan(89°) ≈ ±57.3 range so the user can
-    confirm the posterior is genuinely concentrated rather than
-    artificially auto-scaled to a sub-region.
+    compactified-prior coverage visually honest: each panel shows the
+    full range that was sampled, so the user can confirm the posterior is
+    genuinely concentrated rather than artificially auto-scaled to a
+    sub-region.
 
-    For ``arctan_uniform`` priors the bounds are degrees of the angle
-    variable and the physical sample range is ``tan(deg · π/180)``.
-    For ``log_uniform`` and ``uniform`` priors the ``[low, high]``
-    bounds map directly to the sample axis.
+    ``priors`` already carries the **effective support** per parameter
+    (:func:`_extract_prior_map`), so this function does no bounds
+    interpretation of its own.  It used to: it read ``arctan_uniform``
+    bounds as degrees and drew ±tan(89°) ≈ ±57.3 panels for a prior whose
+    support is ±19.98, over-stating the range ~2.9× and making every
+    posterior look correspondingly more concentrated (GH #451).  That was
+    the v3 design intent (``docs/V3_ARCHITECTURE.md``) which the sampler
+    never implemented (GH #425); the sampler produced the chains, so the
+    sampler is authoritative.
     """
-    import math
-
-    def _physical_bounds(dist: str, lo: float, hi: float) -> tuple[float, float]:
-        if dist == "arctan_uniform":
-            # Map angle-degrees bounds → physical sample bounds via tan.
-            return math.tan(math.radians(lo)), math.tan(math.radians(hi))
-        return lo, hi
-
     for col_idx, col_name in enumerate(plot_params):
         if col_name not in priors:
             continue
-        dist, lo, hi = priors[col_name]
-        x_lo, x_hi = _physical_bounds(dist, lo, hi)
+        _dist, x_lo, x_hi = priors[col_name]
         if not (x_lo < x_hi):
             continue
 
@@ -1542,6 +1538,31 @@ def _overlay_priors(axes_df: object, result: InferenceResult) -> None:
                 alpha=0.8,
                 label="prior",
             )
+        elif dist == "arctan_uniform" and hi > lo:
+            # theta ~ U(-theta_max, theta_max), x = tan(theta), so
+            # p(x) = 1/(2*theta_max) * 1/(1+x^2) — a truncated Cauchy.
+            # Campaign chains are overwhelmingly arctan-prior, so without
+            # this curve the "posterior tracks the prior" null check
+            # (#309) was unavailable for exactly the parameters where the
+            # #420 marginal-D_KL inflation bit hardest.
+            from tidal.inference._prior import _ARCTAN_EPS
+
+            theta_max = math.pi / 2 - _ARCTAN_EPS
+            xs = np.linspace(lo, hi, 400)
+            density = 1.0 / (2.0 * theta_max * (1.0 + xs**2))
+            ax.plot(xs, density, color="red", lw=1.2, alpha=0.8, label="prior")
+        elif dist == "normal" and hi > 0:
+            # Prior's convention for normal: low = mean, high = std.
+            # (lo, hi) here are the effective support, which is infinite
+            # for normal and therefore never reaches this branch via
+            # _extract_prior_map; kept so a directly-injected prior map
+            # renders rather than silently drawing nothing.
+            mu, sigma = lo, hi
+            xs = np.linspace(mu - 4.0 * sigma, mu + 4.0 * sigma, 400)
+            density = np.exp(-0.5 * ((xs - mu) / sigma) ** 2) / (
+                sigma * math.sqrt(2.0 * math.pi)
+            )
+            ax.plot(xs, density, color="red", lw=1.2, alpha=0.8, label="prior")
 
         if xlim is not None:
             ax.set_xlim(xlim)
@@ -1558,16 +1579,35 @@ def _extract_prior_map(
     added ``result.metadata["priors"]``). When replotting old chains
     that pre-date that commit, use ``tidal plot --priors "..."`` to
     inject them via :func:`tidal.inference._prior.parse_prior`.
+
+    The returned bounds are the **effective support** — the range that
+    was actually sampled — taken from the record's
+    ``effective_low``/``effective_high`` when present and reconstructed
+    via :attr:`tidal.inference._prior.Prior.effective_support` otherwise.
+    Archived chains record only the bounds that were typed, which for
+    ``arctan_uniform`` describe nothing (GH #425); reconstructing on read
+    corrects their plots without touching their JSONs (GH #451).
+    Parameters whose support is unbounded (``normal``) are omitted, since
+    every consumer here needs a finite range.
     """
+    import math
+
+    from tidal.inference._prior import effective_support
+
     meta = getattr(result, "metadata", None) or {}
     entries = meta.get("priors") or []
     out: dict[str, tuple[str, float, float]] = {}
     for p in entries:
+        eff: tuple[float, float] | None = None
         if isinstance(p, dict):
             name = p.get("name")
             dist = p.get("distribution") or p.get("dist") or p.get("kind")
             low = p.get("low", p.get("lo"))
             high = p.get("high", p.get("hi"))
+            eff_lo = p.get("effective_low")
+            eff_hi = p.get("effective_high")
+            if eff_lo is not None and eff_hi is not None:
+                eff = (float(eff_lo), float(eff_hi))
         else:
             name = getattr(p, "name", None)
             dist = (
@@ -1577,8 +1617,21 @@ def _extract_prior_map(
             )
             low = getattr(p, "low", None) or getattr(p, "lo", None)
             high = getattr(p, "high", None) or getattr(p, "hi", None)
-        if name and dist and low is not None and high is not None:
-            out[str(name)] = (str(dist), float(low), float(high))
+        if not (name and dist and low is not None and high is not None):
+            continue
+        if eff is None:
+            # Archived record, or a Prior-like object: ask the prior
+            # module what that distribution samples rather than trusting
+            # the bounds.
+            try:
+                eff = effective_support(str(dist), float(low), float(high))
+            except ValueError:
+                # Unknown distribution (e.g. a joint-prior record that
+                # reached here) — no support to speak of; skip it.
+                continue
+        if not (math.isfinite(eff[0]) and math.isfinite(eff[1])):
+            continue
+        out[str(name)] = (str(dist), eff[0], eff[1])
     return out
 
 


### PR DESCRIPTION
Follow-up to the #420-family review, from the four questions raised on the summary: are the guards actually in place for #425, #433 and #434, and is anything still deriving a prior's range from bounds that describe nothing?

Answer: one consumer still was, and it was drawing figures with it.

## #451 (new) — the corner plot carried the same misreading as the estimator

`_set_full_prior_axis_limits` interpreted `arctan_uniform` bounds as **degrees** and drew `--full-prior-bounds` panels over `tan(radians(±89))` = **±57.3**, for a prior whose sampled support is **±19.98** — panels ~2.9× wider than the range, making every posterior look correspondingly more concentrated. That was the v3 design intent (`docs/V3_ARCHITECTURE.md`) which `_prior.py` never implemented (#425). The sampler produced the chains, so the sampler wins.

No committed figure script or campaign template passes `--full-prior-bounds`, so **no recorded figure is affected** — this was latent, not propagated.

Fix is structural rather than local: `_prior.effective_support(dist, low, high)` is now the only place that answers "what range was sampled". `_prior.to_record()` is the only definition of the on-disk prior record. `_extract_prior_map` reconstructs the support for archived chains, so old chains re-plot correctly without their JSONs being touched, and new chains additionally record `effective_low`/`effective_high` (omitted when unbounded — `Infinity` is not valid strict JSON).

Also: prior overlays now render for `arctan_uniform` (truncated Cauchy) and `normal`. Campaign chains are overwhelmingly arctan-prior, so #309's "posterior tracks prior" null check was unavailable for exactly the parameters where the #420 inflation bit hardest.

## #434 — priors missing from a saved chain is now audible

`InferenceResult.save()` warns when a **nested** result has no priors metadata, naming the consequence (post-hoc analysis must reconstruct them). The CLI has recorded priors unconditionally for a while, so this is about every other path into `save()`. It also now serializes live `Prior` objects instead of raising "not JSON serializable" at the last step of a finished run — `compute_parameter_importance` accepts that form, so the two paths now agree on what a prior record is.

## #433 — the last unguarded ranking consumers were the figure scripts

`kl_carrier_corner._pick_top_k` and `overlay_corner_pair._score_from_imp` select each figure's couplings by `max(amp marginal, sup marginal, cross)` with no floor awareness. On an N_eff = 21 chain the marginals are estimator bias of up to ~0.9 nats and out-rank a legitimate cross-KL — so a figure's "carrier" coupling could be selected by noise. Floor-flagged marginals now contribute 0; cross-KL is prior-free and keeps its vote, so real amp-vs-sup structure still ranks.

`floor_dominated_params()` is the shared accessor so every ranking consumer asks the question the same way. It returns empty for a pre-v0.48.8 block: absence means the floors were never computed, not that there are none.

## Verification

- `uv run pytest tests/ -q` → **2685 passed, 5 skipped**
- `uv run pyright` → 0 errors; `ruff check` / `ruff format --check` clean; cspell clean
- `effective_support` for arctan is verified **empirically** — draws must lie inside it and fill it — not just against the formula. Agreement with the sampler is the property both #420 and #451 violated.
- The #451 defect has a direct regression test asserting axes land at ±19.98, with an explicit assertion against reverting to the tan(degrees) reading.
- Adding a prior kind without teaching `effective_support` now fails the suite, matching the existing uniformizing-transform coverage test.

Closes #451. Strengthens #425 (bounds still deliberately unchanged — honoring them would redefine the prior for every archived chain), #433, #434.
