### PR TITLE
Correct the remaining ±57.3 prior-support statements (#451)

### DIFF
--- a/docs/V3_PHASE_D_DESIGN.md
+++ b/docs/V3_PHASE_D_DESIGN.md
@@ -1,5 +1,12 @@
 # Phase D — Manuscript implications of the v3 architecture
 
+> **Correction (2026-08-19, additive — the tables below are preserved as written):**
+> the `arctan_uniform` prior columns describe the range as degrees mapped through
+> `tan`, giving ±57.3. The sampler never did that: `low`/`high` are ignored
+> entirely and the support is fixed at ±tan(π/2 − 0.05) ≈ **±19.98** (GH #425).
+> Read every ±57.3 in this file as ±19.98. Marginal D_KL values quoted here also
+> pre-date the GH #420 estimator fix — see `docs/RESULTS_AMENDMENTS.md`.
+
 **Created:** 2026-05-11
 **Status:** PENDING — gated on Phase B convergence
 **Companion to:** [V3_ARCHITECTURE.md](V3_ARCHITECTURE.md), [V3_PHASE_E_DESIGN.md](V3_PHASE_E_DESIGN.md)

--- a/docs/comparison/d1_amp_v2_v3.md
+++ b/docs/comparison/d1_amp_v2_v3.md
@@ -1,5 +1,12 @@
 # D1 amp — v2 vs v3 comparison
 
+> **Correction (2026-08-19, additive — the tables below are preserved as written):**
+> the `arctan_uniform` prior columns describe the range as degrees mapped through
+> `tan`, giving ±57.3. The sampler never did that: `low`/`high` are ignored
+> entirely and the support is fixed at ±tan(π/2 − 0.05) ≈ **±19.98** (GH #425).
+> Read every ±57.3 in this file as ±19.98. Marginal D_KL values quoted here also
+> pre-date the GH #420 estimator fix — see `docs/RESULTS_AMENDMENTS.md`.
+
 - **v2 reference**: `hpc_results/28896653/`
 - **v3 chain**: `hpc_results/29149987/`
 

--- a/docs/comparison/d20_bahamonde_amp_v2_v3.md
+++ b/docs/comparison/d20_bahamonde_amp_v2_v3.md
@@ -1,5 +1,12 @@
 # d20_bahamonde_amp — v2 vs v3 comparison
 
+> **Correction (2026-08-19, additive — the tables below are preserved as written):**
+> the `arctan_uniform` prior columns describe the range as degrees mapped through
+> `tan`, giving ±57.3. The sampler never did that: `low`/`high` are ignored
+> entirely and the support is fixed at ±tan(π/2 − 0.05) ≈ **±19.98** (GH #425).
+> Read every ±57.3 in this file as ±19.98. Marginal D_KL values quoted here also
+> pre-date the GH #420 estimator fix — see `docs/RESULTS_AMENDMENTS.md`.
+
 - **v2 reference**: `hpc_results/28598736/`
 - **v3 chain**: `hpc_results/29229768/`
 

--- a/docs/comparison/d20_bahamonde_sup_v2_v3.md
+++ b/docs/comparison/d20_bahamonde_sup_v2_v3.md
@@ -1,5 +1,12 @@
 # D2.0 Bahamonde sup: v2 vs v3 comparison
 
+> **Correction (2026-08-19, additive — the tables below are preserved as written):**
+> the `arctan_uniform` prior columns describe the range as degrees mapped through
+> `tan`, giving ±57.3. The sampler never did that: `low`/`high` are ignored
+> entirely and the support is fixed at ±tan(π/2 − 0.05) ≈ **±19.98** (GH #425).
+> Read every ±57.3 in this file as ±19.98. Marginal D_KL values quoted here also
+> pre-date the GH #420 estimator fix — see `docs/RESULTS_AMENDMENTS.md`.
+
 **Status:** Truncated result — supervisor-approved 1-INTR-session policy (2026-05-15).
 The v3 chain was canceled after 7 INTR sessions (job 29271186 canceled at session 8 boundary,
 last completed checkpoint from job 29269357 session 7). Not converged; logZ still changing.

--- a/docs/comparison/d21_barker_amp_v2_v3.md
+++ b/docs/comparison/d21_barker_amp_v2_v3.md
@@ -1,5 +1,12 @@
 # D2.1 Barker amp — v2 vs v3 comparison
 
+> **Correction (2026-08-19, additive — the tables below are preserved as written):**
+> the `arctan_uniform` prior columns describe the range as degrees mapped through
+> `tan`, giving ±57.3. The sampler never did that: `low`/`high` are ignored
+> entirely and the support is fixed at ±tan(π/2 − 0.05) ≈ **±19.98** (GH #425).
+> Read every ±57.3 in this file as ±19.98. Marginal D_KL values quoted here also
+> pre-date the GH #420 estimator fix — see `docs/RESULTS_AMENDMENTS.md`.
+
 - **v2 reference**: `hpc_results/d21_barker_amp/`
 - **v3 chain**: `hpc_results/d21_barker_amp_v3/`
 

--- a/docs/comparison/stage_a_amp_v2_v3.md
+++ b/docs/comparison/stage_a_amp_v2_v3.md
@@ -1,5 +1,12 @@
 # stage_a_amp — v2 vs v3 comparison
 
+> **Correction (2026-08-19, additive — the tables below are preserved as written):**
+> the `arctan_uniform` prior columns describe the range as degrees mapped through
+> `tan`, giving ±57.3. The sampler never did that: `low`/`high` are ignored
+> entirely and the support is fixed at ±tan(π/2 − 0.05) ≈ **±19.98** (GH #425).
+> Read every ±57.3 in this file as ±19.98. Marginal D_KL values quoted here also
+> pre-date the GH #420 estimator fix — see `docs/RESULTS_AMENDMENTS.md`.
+
 - **v2 reference**: `hpc_results/28474676/`
 - **v3 chain**: `hpc_results/29189966/`
 

--- a/docs/comparison/stage_a_sup_v2_v3.md
+++ b/docs/comparison/stage_a_sup_v2_v3.md
@@ -1,5 +1,12 @@
 # stage_a_sup — v2 vs v3 comparison
 
+> **Correction (2026-08-19, additive — the tables below are preserved as written):**
+> the `arctan_uniform` prior columns describe the range as degrees mapped through
+> `tan`, giving ±57.3. The sampler never did that: `low`/`high` are ignored
+> entirely and the support is fixed at ±tan(π/2 − 0.05) ≈ **±19.98** (GH #425).
+> Read every ±57.3 in this file as ±19.98. Marginal D_KL values quoted here also
+> pre-date the GH #420 estimator fix — see `docs/RESULTS_AMENDMENTS.md`.
+
 - **v2 reference**: `hpc_results/28477675/`
 - **v3 chain**: `hpc_results/29199129/`
 

--- a/tidal/inference/_visualize.py
+++ b/tidal/inference/_visualize.py
@@ -81,11 +81,16 @@ def plot_corner(
       posterior.
 
     The ``full_prior_bounds`` flag (v3 architecture) overrides the
-    anesthetic per-panel auto-scale with the full prior range, so that
-    compactified ``arctan_uniform`` priors visibly span their full
-    ±tan(89°) ≈ ±57.3 sample range.  Useful when the user needs to
-    confirm posterior compactness rather than read marginal shape.
-    Only supported by the anesthetic backend.
+    anesthetic per-panel auto-scale with the full range each prior
+    actually sampled (:func:`tidal.inference._prior.effective_support`),
+    so a compactified ``arctan_uniform`` parameter spans its full
+    ±19.98 support.  Useful when the user needs to confirm posterior
+    compactness rather than read marginal shape.  Only supported by the
+    anesthetic backend.
+
+    (Before v0.49.2 this docstring and the implementation both claimed
+    ±tan(89°) ≈ ±57.3, reading the recorded bounds as degrees — bounds
+    that ``arctan_uniform`` ignores entirely.  See GH #451/#425.)
     """
     try:
         _plot_corner_anesthetic(


### PR DESCRIPTION
Follow-up to #452, from re-grepping the tree after it merged. The code was fixed; two classes of *statement* were not.

**`plot_corner`'s docstring — a live API contract.** It still promised that `--full-prior-bounds` makes panels "span their full ±tan(89°) ≈ ±57.3 sample range". That is now false twice over: it is not what the flag does after #452, and it never described what the prior sampled. Rewritten to name `effective_support`; the old claim is kept as a dated parenthetical rather than erased.

**Seven campaign comparison records** state the prior as `arctan[-89°..89°] → ±57.3` in their per-parameter tables (`docs/comparison/*_v2_v3.md`, `docs/V3_PHASE_D_DESIGN.md`). These are dated records of what was believed at the time, so per the history-preserving policy **no table is edited** — each file gains an additive correction banner giving the real ±19.98 support, and noting that the marginal D_KL values in the same tables pre-date the #420 fix (pointer to `RESULTS_AMENDMENTS.md`).

After this, `grep -rn "57.3"` over the tree returns only historical text that sits under a correction banner, plus the CAMPAIGN/architecture entries that already carry their own amendments.

Verification: `ruff check` / `ruff format --check` clean, cspell clean, `tests/test_inference.py` 115 passed. Docs and one docstring only — no behavior change.